### PR TITLE
Staking audit changes

### DIFF
--- a/contracts/mock/DummyTokenMock.sol
+++ b/contracts/mock/DummyTokenMock.sol
@@ -73,7 +73,7 @@ contract DummyTokenMock is ERC20 {
         returns (bool)
     {
         // _transferFrom(from, to, value);
-        return false;
+        return retBit;
     }
 
     /**

--- a/contracts/mock/MockStaking.sol
+++ b/contracts/mock/MockStaking.sol
@@ -4,7 +4,7 @@ import "../Staking.sol";
 
 contract MockStaking is Staking {
 
-  constructor(address _stakeToken, address _rewardToken, uint256 stakingPeriod, uint256 _totalRewardToBeDistributed, uint256 startTime) public Staking(_stakeToken, _rewardToken, stakingPeriod, _totalRewardToBeDistributed, startTime) {
+  constructor(address _stakeToken, address _rewardToken, uint256 stakingPeriod, uint256 _totalRewardToBeDistributed, uint256 startTime, address vaultAdd) public Staking(_stakeToken, _rewardToken, stakingPeriod, _totalRewardToBeDistributed, startTime, vaultAdd) {
   }
 
 	function setBuyInRate(address _user, uint _value) public

--- a/test/StakingTestCases.test.js
+++ b/test/StakingTestCases.test.js
@@ -643,6 +643,43 @@ contract("InterestDistribution - Scenario based calculations for staking model",
         expect((stakerData[0]).toString()).to.be.equal(web3.utils.toWei("460", "ether")); 
     });
 
+    it("Staker 1 stakes 100 Token at 95th block", async () => {
+
+      let beforeStakeTokBal = await stakeTok.balanceOf(S1);
+
+      let beforeStakeTokBalStaking = await stakeTok.balanceOf(staking.address);
+
+      // increase block
+      await evm_mine(stakeStartTime/1+94-(await web3.eth.getBlock('latest')).number);
+
+      
+      await staking.stake(toWei("100"), {
+          from: S1
+        });
+
+        let afterStakeTokBal = await stakeTok.balanceOf(S1);
+
+        let afterStakeTokBalStaking = await stakeTok.balanceOf(staking.address);
+
+        expect((beforeStakeTokBal - afterStakeTokBal)).to.be.equal((toWei("100"))/1);
+        expect((afterStakeTokBalStaking - beforeStakeTokBalStaking)).to.be.equal((toWei("100"))/1); 
+
+        let stakerData = await staking.getStakerData(S1);
+        let interestData = await staking.interestData();
+        let yieldData = await staking.getYieldData(S1);
+
+          
+        expect((Math.floor(yieldData[0]/1e18)).toString()).to.be.equal("940");
+        expect((Math.floor(yieldData[1]/1e18)).toString()).to.be.equal("272682");
+
+        // globalTotalStake
+        expect((interestData[0]).toString()).to.be.equal(toWei("820")); 
+        
+
+        // totalStake of S1
+        expect((stakerData[0]).toString()).to.be.equal(web3.utils.toWei("360", "ether")); 
+    });
+
     it("Computing updated yield data at 100th block", async () => {
 
       // increase block
@@ -650,15 +687,15 @@ contract("InterestDistribution - Scenario based calculations for staking model",
 
       let statsDta = await staking.getStatsData(S1);
 
-      expect((Math.floor((statsDta[0])/1e18)).toString()).to.be.equal("720");
+      expect((Math.floor((statsDta[0])/1e18)).toString()).to.be.equal("820");
       expect((Math.floor((statsDta[1])/1e18)).toString()).to.be.equal("500000");
-      expect((Math.floor((statsDta[2])/1e18)).toString()).to.be.equal("74831");
+      expect((Math.floor((statsDta[2])/1e18)).toString()).to.be.equal("76779");
       expect((Math.floor((statsDta[3])/1e18)).toString()).to.be.equal("495000");
-      expect((Math.floor((statsDta[4])/1e18)).toString()).to.be.equal("73026");
+      expect((Math.floor((statsDta[4])/1e18)).toString()).to.be.equal("74584");
 
       statsDta = await staking.getStatsData(S2);
 
-      expect((Math.floor((statsDta[0])/1e18)).toString()).to.be.equal("720");
+      expect((Math.floor((statsDta[0])/1e18)).toString()).to.be.equal("820");
       expect((Math.floor((statsDta[1])/1e18)).toString()).to.be.equal("500000");
       expect((Math.floor((statsDta[2])/1e18)).toString()).to.be.equal("0");
       expect((Math.floor((statsDta[3])/1e18)).toString()).to.be.equal("495000");
@@ -666,11 +703,11 @@ contract("InterestDistribution - Scenario based calculations for staking model",
 
       statsDta = await staking.getStatsData(S3);
 
-      expect((Math.floor((statsDta[0])/1e18)).toString()).to.be.equal("720");
+      expect((Math.floor((statsDta[0])/1e18)).toString()).to.be.equal("820");
       expect((Math.floor((statsDta[1])/1e18)).toString()).to.be.equal("500000");
-      expect((Math.floor((statsDta[2])/1e18)).toString()).to.be.equal("150165");
+      expect((Math.floor((statsDta[2])/1e18)).toString()).to.be.equal("148217");
       expect((Math.floor((statsDta[3])/1e18)).toString()).to.be.equal("495000");
-      expect((Math.floor((statsDta[4])/1e18)).toString()).to.be.equal("146970");
+      expect((Math.floor((statsDta[4])/1e18)).toString()).to.be.equal("145412");
 
          
     
@@ -684,17 +721,17 @@ contract("InterestDistribution - Scenario based calculations for staking model",
 
       
           
-      expect((Math.floor(interestData[1]/1e18)).toString()).to.be.equal("974");
+      expect((Math.floor(interestData[1]/1e18)).toString()).to.be.equal("970");
 
       // globalTotalStake
-      expect((interestData[0]).toString()).to.be.equal(web3.utils.toWei("720", "ether")); 
+      expect((interestData[0]).toString()).to.be.equal(web3.utils.toWei("820", "ether")); 
     
       
-      expect((Math.floor((await staking.calculateInterest(S1))/1e18)).toString()).to.be.equal("74831");
+      expect((Math.floor((await staking.calculateInterest(S1))/1e18)).toString()).to.be.equal("76779");
       
       expect((Math.floor((await staking.calculateInterest(S2))/1e18)).toString()).to.be.equal("0");
       
-      expect((Math.floor((await staking.calculateInterest(S3))/1e18)).toString()).to.be.equal("150165");
+      expect((Math.floor((await staking.calculateInterest(S3))/1e18)).toString()).to.be.equal("148217");
     });
   });
 
@@ -711,7 +748,7 @@ contract("InterestDistribution - Scenario based calculations for staking model",
       // increase time
       await evm_mine(50);
 
-      await staking.withdrawStakeAndInterest(toWei("260"), {
+      await staking.withdrawStakeAndInterest(toWei("360"), {
         from: S1
       });
 
@@ -728,18 +765,18 @@ contract("InterestDistribution - Scenario based calculations for staking model",
       let afterstakeTokBalStaking = await stakeTok.balanceOf(staking.address);
       let afterPlotBalStaking = await plotusToken.balanceOf(staking.address);
 
-      expect((Math.floor((afterPlotBalS1 - beforePlotBalS1)/1e18)).toString()).to.be.equal("74831");
-      expect((Math.floor((afterPlotBalS3 - beforePlotBalS3)/1e18)).toString()).to.be.equal("150165");
+      expect((Math.floor((afterPlotBalS1 - beforePlotBalS1)/1e18)).toString()).to.be.equal("76779");
+      expect((Math.floor((afterPlotBalS3 - beforePlotBalS3)/1e18)).toString()).to.be.equal("148217");
       expect((Math.floor((afterPlotBalStaking)/1e18)).toString()).to.be.equal("50000"); 
 
-      expect((Math.floor((afterstakeTokBalS1 - beforestakeTokBalS1)/1e18)).toString()).to.be.equal("260");
+      expect((Math.floor((afterstakeTokBalS1 - beforestakeTokBalS1)/1e18)).toString()).to.be.equal("360");
       expect((Math.floor((afterstakeTokBalS3 - beforestakeTokBalS3)/1e18)).toString()).to.be.equal("460");
       expect((Math.floor((afterstakeTokBalStaking)/1e18)).toString()).to.be.equal("0");
       
       let interestData = await staking.interestData();
       
           
-      expect((Math.floor(interestData[1]/1e18)).toString()).to.be.equal("974");
+      expect((Math.floor(interestData[1]/1e18)).toString()).to.be.equal("970");
 
       // globalTotalStake
       expect((interestData[0]).toString()).to.be.equal(toWei("0")); 

--- a/test/StakingTestCases.test.js
+++ b/test/StakingTestCases.test.js
@@ -20,7 +20,7 @@ async function evm_mine(blocks) {
     );
 }
 
-contract("InterestDistribution - Scenario based calculations for staking model", ([S1, S2, S3]) => {
+contract("InterestDistribution - Scenario based calculations for staking model", ([S1, S2, S3, vaultAdd]) => {
   let stakeTok,
       plotusToken,
       staking,
@@ -37,9 +37,9 @@ contract("InterestDistribution - Scenario based calculations for staking model",
       dummyRewardTok = await DummyTokenMock.new("PLT","PLT");
       let nowTime = await latestTime();
       console.log((await web3.eth.getBlock('latest')).number);
-      staking = await Staking.new(stakeTok.address, plotusToken.address, 100, toWei(500000), ((await web3.eth.getBlock('latest')).number)/1+4);
+      staking = await Staking.new(stakeTok.address, plotusToken.address, 100, toWei(500000), ((await web3.eth.getBlock('latest')).number)/1+4, vaultAdd);
 
-      dummyStaking = await MockStaking.new(dummystakeTok.address, dummyRewardTok.address, 100, toWei(500000), ((await web3.eth.getBlock('latest')).number)/1+1);
+      dummyStaking = await MockStaking.new(dummystakeTok.address, dummyRewardTok.address, 100, toWei(500000), ((await web3.eth.getBlock('latest')).number)/1+1, vaultAdd);
 
       await plotusToken.transfer(staking.address, toWei(500000));
 
@@ -68,6 +68,7 @@ contract("InterestDistribution - Scenario based calculations for staking model",
 
       let beforeStakeTokBal = await stakeTok.balanceOf(S1);
       let beforeStakeTokBalStaking = await stakeTok.balanceOf(staking.address);
+      let vaultBal = await plotusToken.balanceOf(vaultAdd);
       // increase block
       await evm_mine(stakeStartTime/1+9-(await web3.eth.getBlock('latest')).number);
       /**
@@ -77,6 +78,7 @@ contract("InterestDistribution - Scenario based calculations for staking model",
           from: S1
         });
 
+        let vaultBalAfter = await plotusToken.balanceOf(vaultAdd);
 
         let afterStakeTokBal = await stakeTok.balanceOf(S1);
 
@@ -84,6 +86,7 @@ contract("InterestDistribution - Scenario based calculations for staking model",
 
         expect((beforeStakeTokBal - afterStakeTokBal)).to.be.equal((toWei("100", "ether"))/1);
         expect((afterStakeTokBalStaking - beforeStakeTokBalStaking)).to.be.equal((toWei("100", "ether"))/1); 
+        expect((vaultBalAfter - vaultBal)).to.be.equal((toWei("50000", "ether"))/1);
 
 
         let stakerData = await staking.getStakerData(S1);
@@ -767,7 +770,7 @@ contract("InterestDistribution - Scenario based calculations for staking model",
 
       expect((Math.floor((afterPlotBalS1 - beforePlotBalS1)/1e18)).toString()).to.be.equal("76779");
       expect((Math.floor((afterPlotBalS3 - beforePlotBalS3)/1e18)).toString()).to.be.equal("148217");
-      expect((Math.floor((afterPlotBalStaking)/1e18)).toString()).to.be.equal("50000"); 
+      expect((Math.floor((afterPlotBalStaking)/1e18)).toString()).to.be.equal("0"); 
 
       expect((Math.floor((afterstakeTokBalS1 - beforestakeTokBalS1)/1e18)).toString()).to.be.equal("360");
       expect((Math.floor((afterstakeTokBalS3 - beforestakeTokBalS3)/1e18)).toString()).to.be.equal("460");
@@ -823,13 +826,20 @@ contract("InterestDistribution - Scenario based calculations for staking model",
   });
   
   describe('reverts', function() {
-    it("Should revert if transer token failed while staking", async () => {
+    it("Should revert if transfer token failed while staking", async () => {
 
       await assertRevert(dummyStaking.stake(100, {
         from: S1
       }));
     });
-    it("Should revert if transer token failed while unstaking", async () => {
+    it("Should revert if transfer token failed while transfering to vault", async () => {
+
+      await assertRevert(dummyStaking.updateGlobalYield( {
+        from: S1
+      }));
+      
+    });
+    it("Should revert if transfer token failed while unstaking", async () => {
       await dummyStaking.addStake(S1, 200);
       await dummyStaking.setInterestData(200, toWei(10));
       await dummyRewardTok.setRetBit(true);
@@ -855,23 +865,27 @@ contract("InterestDistribution - Scenario based calculations for staking model",
     });
     it("Should Revert if staking period pass as 0", async () => {
       let nowBlock = (await web3.eth.getBlock('latest')).number;
-      await assertRevert(Staking.new(stakeTok.address, plotusToken.address, 0, toWei(500000), nowBlock/1+2));
+      await assertRevert(Staking.new(stakeTok.address, plotusToken.address, 0, toWei(500000), nowBlock/1+2, vaultAdd));
     });
     it("Should Revert if reward pass as 0", async () => {
       let nowBlock = (await web3.eth.getBlock('latest')).number;
-      await assertRevert(Staking.new(stakeTok.address, plotusToken.address, 120, 0, nowBlock/1+2));
+      await assertRevert(Staking.new(stakeTok.address, plotusToken.address, 120, 0, nowBlock/1+2, vaultAdd));
     });
     it("Should Revert if start time pass as past time", async () => {
       let nowBlock = (await web3.eth.getBlock('latest')).number;
-      await assertRevert(Staking.new(stakeTok.address, plotusToken.address, 1, 120, nowBlock-15));
+      await assertRevert(Staking.new(stakeTok.address, plotusToken.address, 1, 120, nowBlock-15, vaultAdd));
     });
     it("Should Revert if stake token is null", async () => {
       let nowBlock = (await web3.eth.getBlock('latest')).number;
-      await assertRevert(Staking.new(nullAddress, plotusToken.address, 1, 120, nowBlock/1+2));
+      await assertRevert(Staking.new(nullAddress, plotusToken.address, 1, 120, nowBlock/1+2, vaultAdd));
     });
     it("Should Revert if reward token is null", async () => {
       let nowBlock = (await web3.eth.getBlock('latest')).number;
-      await assertRevert(Staking.new(stakeTok.address, nullAddress, 1, 120, nowBlock/1+2));
+      await assertRevert(Staking.new(stakeTok.address, nullAddress, 1, 120, nowBlock/1+2, vaultAdd));
+    });
+    it("Should Revert if vault address is null", async () => {
+      let nowBlock = (await web3.eth.getBlock('latest')).number;
+      await assertRevert(Staking.new(stakeTok.address, plotusToken.address, 1, 120, nowBlock/1+2, nullAddress));
     });
   });
 


### PR DESCRIPTION
PR consist of following changes.

Added test case for 95th block, where staker 1 stakes more after unstaking.
Added vault address to collect unclaimed reward.
Added globalYieldPerToken in all events.