### PR TITLE
Fix/audit issues

### DIFF
--- a/.solcover.js
+++ b/.solcover.js
@@ -5,6 +5,7 @@ module.exports = {
     network_id: 5777,
     mnemonic:
       'grocery obvious wire insane limit weather parade parrot patrol stock blast ivory',
-    total_accounts: 47
+    total_accounts: 47,
+    hardfork: 'constantinople'
   }
 };

--- a/contracts/Governance.sol
+++ b/contracts/Governance.sol
@@ -1122,7 +1122,7 @@ contract Governance is IGovernance, Iupgradable {
         roleIdAllowedToCatgorize = uint256(IMemberRoles.Role.AdvisoryBoard);
         minTokenLockedForDR = 1000 ether;
         lockTimeForDR = 15 days;
-        actionWaitingTime = 1 hours;
+        actionWaitingTime = 1 days;
         actionRejectAuthRole = uint256(IMemberRoles.Role.AdvisoryBoard);
         votePercRejectAction = 60;
         maxVoteWeigthPer = 5;

--- a/contracts/Governance.sol
+++ b/contracts/Governance.sol
@@ -201,7 +201,7 @@ contract Governance is IGovernance, Iupgradable {
         if(keccak256(_functionHash) == swapABMemberHash) {
             incentive = 0;
         }
-        _categorizeProposal(_proposalId, _categoryId, incentive);
+        _categorizeProposal(_proposalId, _categoryId, incentive, _functionHash);
     }
 
     /**
@@ -728,7 +728,7 @@ contract Governance is IGovernance, Iupgradable {
             if(keccak256(_functionHash) == swapABMemberHash) {
                 defaultIncentive = 0;
             }
-            _categorizeProposal(_proposalId, _categoryId, defaultIncentive);
+            _categorizeProposal(_proposalId, _categoryId, defaultIncentive, _functionHash);
         }
     }
 
@@ -741,12 +741,16 @@ contract Governance is IGovernance, Iupgradable {
     function _categorizeProposal(
         uint256 _proposalId,
         uint256 _categoryId,
-        uint256 _incentive
+        uint256 _incentive,
+        bytes memory _functionHash
     ) internal {
         require(
             _categoryId > 0 && _categoryId < proposalCategory.totalCategories(),
             "Invalid category"
         );
+        if(keccak256(_functionHash) == resolveDisputeHash) {
+            require(msg.sender == address(marketRegistry));
+        }
         allProposalData[_proposalId].category = _categoryId;
         allProposalData[_proposalId].commonIncentive = _incentive;
         allProposalData[_proposalId].propStatus = uint256(

--- a/contracts/Governance.sol
+++ b/contracts/Governance.sol
@@ -280,6 +280,10 @@ contract Governance is IGovernance, Iupgradable {
             uint256(ProposalStatus.VotingStarted)
         ) {
             _updateProposalStatus(_proposalId, uint256(ProposalStatus.Denied));
+            _transferPLOT(
+                address(marketRegistry),
+                allProposalData[_proposalId].commonIncentive
+            );
         } else {
             require(canCloseProposal(_proposalId) == 1);
             _closeVote(_proposalId, category);
@@ -337,7 +341,10 @@ contract Governance is IGovernance, Iupgradable {
         }
 
         if (j > 0) {
-            tokenInstance.transfer(_memberAddress, pendingDAppReward);
+            _transferPLOT(
+                _memberAddress,
+                pendingDAppReward
+            );
             emit RewardClaimed(_memberAddress, pendingDAppReward);
         }
     }
@@ -1088,9 +1095,18 @@ contract Governance is IGovernance, Iupgradable {
         }
 
         if (proposalVoteTally[_proposalId].voters == 0 && allProposalData[_proposalId].commonIncentive > 0) {
-            tokenInstance.transfer(
+            _transferPLOT(
                 address(marketRegistry),
                 allProposalData[_proposalId].commonIncentive
+            );
+        }
+    }
+
+    function _transferPLOT(address _recipient, uint256 _amount) internal {
+        if(_amount > 0) {
+            tokenInstance.transfer(
+                _recipient,
+                _amount
             );
         }
     }

--- a/contracts/Market.sol
+++ b/contracts/Market.sol
@@ -53,6 +53,7 @@ contract Market {
     ITokenController constant tokenController = ITokenController(0x3A3d9ca9d9b25AF1fF7eB9d8a1ea9f61B5892Ee9);
     IMarketUtility constant marketUtility = IMarketUtility(0xCBc7df3b8C870C5CDE675AaF5Fd823E4209546D2);
 
+    uint8 constant roundOfToNearest = 25;
     uint constant totalOptions = 3;
     uint constant MAX_LEVERAGE = 5;
     uint constant ethCommissionPerc = 10; //with 2 decimals
@@ -376,8 +377,8 @@ contract Market {
     * @return market currency name
     * @return market currency feed address
     */
-    function getMarketFeedData() public view returns(bytes32, address) {
-      return (marketCurrency, marketFeedAddress);
+    function getMarketFeedData() public view returns(uint8, bytes32, address) {
+      return (roundOfToNearest, marketCurrency, marketFeedAddress);
     }
 
    /**

--- a/contracts/Market.sol
+++ b/contracts/Market.sol
@@ -219,12 +219,12 @@ contract Market {
       require(_value > 0,"value should be greater than 0");
       uint riskPercentage;
       ( , riskPercentage, , ) = marketUtility.getBasicMarketDetails();
-      predictionStatus = PredictionStatus.Settled;
-      if(marketStatus() != PredictionStatus.InDispute) {
+      if(predictionStatus != PredictionStatus.InDispute) {
         marketSettleData.settleTime = uint64(now);
       } else {
         delete marketSettleData.settleTime;
       }
+      predictionStatus = PredictionStatus.Settled;
       if(_value < marketData.neutralMinValue) {
         marketSettleData.WinningOption = 1;
       } else if(_value > marketData.neutralMaxValue) {

--- a/contracts/Market.sol
+++ b/contracts/Market.sol
@@ -131,7 +131,7 @@ contract Market {
       } else {
         require(msg.value == 0);
         if (_asset == plotToken){
-          require(IToken(_asset).transferFrom(msg.sender, address(this), _predictionStake));
+          tokenController.transferFrom(plotToken, msg.sender, address(this), _predictionStake);
         } else {
           require(_asset == tokenController.bLOTToken());
           require(_leverage == MAX_LEVERAGE);
@@ -274,7 +274,7 @@ contract Market {
     function raiseDispute(uint256 proposedValue, string memory proposalTitle, string memory description, string memory solutionHash) public {
       require(marketStatus() == PredictionStatus.Cooling);
       uint _stakeForDispute =  marketUtility.getDisputeResolutionParams();
-      require(IToken(plotToken).transferFrom(msg.sender, address(marketRegistry), _stakeForDispute));
+      tokenController.transferFrom(plotToken, msg.sender, address(marketRegistry), _stakeForDispute);
       lockedForDispute = true;
       marketRegistry.createGovernanceProposal(proposalTitle, description, solutionHash, abi.encode(address(this), proposedValue), _stakeForDispute, msg.sender, ethAmountToPool, tokenAmountToPool, proposedValue);
       delete ethAmountToPool;
@@ -302,7 +302,7 @@ contract Market {
       require(incentiveToken == address(0), "Already sponsored");
       incentiveToken = _token;
       incentiveToDistribute = _value;
-      require(IToken(_token).transferFrom(msg.sender, address(this), _value));
+      tokenController.transferFrom(_token, msg.sender, address(this), _value);
     }
 
 

--- a/contracts/MarketRegistry.sol
+++ b/contracts/MarketRegistry.sol
@@ -139,9 +139,9 @@ contract MarketRegistry is Governed, Iupgradable {
       require(marketTypes.length == 0);
       _addNewMarketCurrency(_ethMarketImplementation);
       _addNewMarketCurrency(_btcMarketImplementation);
-      _addMarket(1 hours, 20);
-      _addMarket(24 hours, 50);
-      _addMarket(7 days, 100);
+      _addMarket(1 hours, 50);
+      _addMarket(24 hours, 200);
+      _addMarket(7 days, 500);
 
       for(uint256 i = 0;i < marketTypes.length; i++) {
           marketCreationData[i][0].initialStartTime = _marketStartTime;
@@ -155,6 +155,7 @@ contract MarketRegistry is Governed, Iupgradable {
     * @dev Add new market type.
     * @param _predictionTime The time duration of market.
     * @param _marketStartTime The time at which market will create.
+    * @param _optionRangePerc Option range percent of neutral min, max options (raised by 2 decimals)
     */
     function addNewMarketType(uint64 _predictionTime, uint64 _marketStartTime, uint64 _optionRangePerc) external onlyAuthorizedToGovern {
       require(_marketStartTime > now);
@@ -166,6 +167,11 @@ contract MarketRegistry is Governed, Iupgradable {
       }
     }
 
+    /**
+    * @dev Internal function to add market type
+    * @param _predictionTime The time duration of market.
+    * @param _optionRangePerc Option range percent of neutral min, max options (raised by 2 decimals)
+    */
     function _addMarket(uint64 _predictionTime, uint64 _optionRangePerc) internal {
       uint256 _marketType = marketTypes.length;
       marketTypes.push(MarketTypeData(_predictionTime, _optionRangePerc));
@@ -261,7 +267,7 @@ contract MarketRegistry is Governed, Iupgradable {
       uint64 _marketStartTime = calculateStartTimeForMarket(_marketType, _marketCurrencyIndex);
       uint64 _optionRangePerc = marketTypes[_marketType].optionRangePerc;
       uint currentPrice = marketUtility.getAssetPriceUSD(_priceFeed);
-      _optionRangePerc = uint64(currentPrice.mul(_optionRangePerc.div(2)).div(1000));
+      _optionRangePerc = uint64(currentPrice.mul(_optionRangePerc.div(2)).div(10000));
       uint64 _minValue = uint64(currentPrice.sub(_optionRangePerc));
       uint64 _maxValue = uint64(currentPrice.add(_optionRangePerc));
       _createMarket(_marketType, _marketCurrencyIndex, _minValue, _maxValue, _marketStartTime, _currencyName);

--- a/contracts/MarketRegistry.sol
+++ b/contracts/MarketRegistry.sol
@@ -283,10 +283,9 @@ contract MarketRegistry is Governed, Iupgradable {
     function claimCreationReward() external {
       require(userData[msg.sender].marketsCreated > 0);
       uint256 pendingReward = marketCreationIncentive.mul(userData[msg.sender].marketsCreated);
-      if(plotToken.balanceOf(address(this)) > pendingReward) {
-        delete userData[msg.sender].marketsCreated;
-        _transferAsset(address(plotToken), msg.sender, pendingReward);
-      }
+      require(plotToken.balanceOf(address(this)) > pendingReward);
+      delete userData[msg.sender].marketsCreated;
+      _transferAsset(address(plotToken), msg.sender, pendingReward);
     }
 
     function calculateStartTimeForMarket(uint256 _marketType, uint256 _marketCurrencyIndex) public view returns(uint64 _marketStartTime) {

--- a/contracts/MarketRegistry.sol
+++ b/contracts/MarketRegistry.sol
@@ -18,7 +18,6 @@ import "./external/openzeppelin-solidity/math/SafeMath.sol";
 import "./external/govblocks-protocol/interfaces/IGovernance.sol";
 import "./external/govblocks-protocol/Governed.sol";
 import "./external/proxy/OwnedUpgradeabilityProxy.sol";
-import "./external/string-utils/strings.sol";
 import "./interfaces/IToken.sol";
 import "./interfaces/IMarket.sol";
 import "./interfaces/Iupgradable.sol";
@@ -27,7 +26,6 @@ import "./interfaces/IMarketUtility.sol";
 contract MarketRegistry is Governed, Iupgradable {
 
     using SafeMath for *; 
-    using strings for *; 
 
     enum MarketType {
       HourlyMarket,

--- a/contracts/MarketUtility.sol
+++ b/contracts/MarketUtility.sol
@@ -234,6 +234,13 @@ contract MarketUtility {
     }
 
     /**
+    * @dev Get decimals of given price feed address 
+    */
+    function getPriceFeedDecimals(address _priceFeed) public view returns(uint8) {
+      return IChainLinkOracle(_priceFeed).decimals();
+    }
+
+    /**
      * @dev Get basic market details
      * @return Minimum amount required to predict in market
      * @return Percentage of users leveraged amount to deduct when placed in wrong prediction

--- a/contracts/PlotXToken.sol
+++ b/contracts/PlotXToken.sol
@@ -97,20 +97,6 @@ contract PlotXToken is ERC20 {
     }
 
     /**
-     * @dev Transfer tokens to the operator from the specified address
-     * @param from The address to transfer from.
-     * @param value The amount to be transferred.
-     */
-    function operatorTransfer(address from, uint256 value)
-        public
-        onlyOperator
-        returns (bool)
-    {
-        _transfer(from, operator, value);
-        return true;
-    }
-
-    /**
      * @dev Transfer tokens from one address to another
      * @param from address The address which you want to send tokens from
      * @param to address The address which you want to transfer to

--- a/contracts/TokenController.sol
+++ b/contracts/TokenController.sol
@@ -116,7 +116,7 @@ contract TokenController is IERC1132, Governed, Iupgradable {
 
         lockReason[msg.sender].push(_reason);
 
-        token.operatorTransfer(msg.sender, _amount);
+        require(token.transferFrom(msg.sender, address(this), _amount));
 
         locked[msg.sender][_reason] = LockToken(_amount, validUntil, false);
 
@@ -191,7 +191,7 @@ contract TokenController is IERC1132, Governed, Iupgradable {
         require(_reason == "SM" || _reason == "DR","Unspecified reason");
         require(_amount != 0, AMOUNT_ZERO);
         require(tokensLocked(msg.sender, _reason) > 0, NOT_LOCKED);
-        token.operatorTransfer(msg.sender, _amount);
+        require(token.transferFrom(msg.sender, address(this), _amount));
 
         locked[msg.sender][_reason].amount = locked[msg.sender][_reason].amount.add(_amount);
         if(_reason == "SM") {

--- a/contracts/TokenController.sol
+++ b/contracts/TokenController.sol
@@ -67,6 +67,10 @@ contract TokenController is IERC1132, Governed, Iupgradable {
         marketRegistry = IMarketRegistry(address(uint160(ms.getLatestAddress("PL"))));
     }
 
+    /**
+     * @dev Initiate vesting contract
+     * @param _vesting Address of vesting contract implementation
+     */
     function initiateVesting(address _vesting) external {
         OwnedUpgradeabilityProxy proxy =  OwnedUpgradeabilityProxy(address(uint160(address(this))));
         require(msg.sender == proxy.proxyOwner(),"Sender is not proxy owner.");
@@ -74,8 +78,25 @@ contract TokenController is IERC1132, Governed, Iupgradable {
 
     }
 
-    function swapBLOT(address _of, address _to, uint256 amount) public onlyAuthorized {
-        bLOTToken.convertToPLOT(_of, _to, amount);
+    /**
+     * @dev Swap `_amount` of BPLOT belonging to `_of` to PLOT and transfer to `_to` address
+     * @param _of Address from whose BPLOT to be transferred
+     * @param _to Recipient address, who recieves PLOT
+     * @param _amount Amount of tokens to swap
+     */
+    function swapBLOT(address _of, address _to, uint256 _amount) public onlyAuthorized {
+        bLOTToken.convertToPLOT(_of, _to, _amount);
+    }
+
+    /**
+     * @dev Transfers `_amount` of `_token` token from `_of` to `_to`
+     * @param _token Token address
+     * @param _of Address from whose PLOT to be transferred
+     * @param _to Recipient address
+     * @param _amount Amount of tokens to transfer
+     */
+    function transferFrom(address _token, address _of, address _to, uint256 _amount) public onlyAuthorized {
+        require(IToken(_token).transferFrom(_of, _to, _amount));
     }
 
     /**

--- a/contracts/TokenController.sol
+++ b/contracts/TokenController.sol
@@ -293,7 +293,7 @@ contract TokenController is IERC1132, Governed, Iupgradable {
         returns (bool)
     {
         require(_reason == "DR","Reason must be DR");
-        uint256 amount = tokensLocked(_of, _reason);
+        uint256 amount = tokensLockedAtTime(_of, _reason, now);
         require(amount >= _amount, "Tokens locked must be greater than amount");
 
         locked[_of][_reason].amount = locked[_of][_reason].amount.sub(_amount);

--- a/contracts/external/uniswap/FixedPoint.sol
+++ b/contracts/external/uniswap/FixedPoint.sol
@@ -19,6 +19,20 @@ library Babylonian {
     }
 }
 
+library UQ112x112 {
+    uint224 constant Q112 = 2**112;
+
+    // encode a uint112 as a UQ112x112
+    function encode(uint112 y) internal pure returns (uint224 z) {
+        z = uint224(y) * Q112; // never overflows
+    }
+
+    // divide a UQ112x112 by a uint112, returning a UQ112x112
+    function uqdiv(uint224 x, uint112 y) internal pure returns (uint224 z) {
+        z = x / uint224(y);
+    }
+}
+
 // a library for handling binary fixed point numbers (https://en.wikipedia.org/wiki/Q_(number_format))
 library FixedPoint {
     // range: [0, 2**112 - 1]

--- a/contracts/external/uniswap/solidity-interface.sol
+++ b/contracts/external/uniswap/solidity-interface.sol
@@ -77,3 +77,29 @@ interface IUniswapV2Pair {
     function initialize(address, address) external;
 }
 
+interface IUniswapV2ERC20 {
+    event Approval(address indexed owner, address indexed spender, uint value);
+    event Transfer(address indexed from, address indexed to, uint value);
+
+    function name() external pure returns (string memory);
+    function symbol() external pure returns (string memory);
+    function decimals() external pure returns (uint8);
+    function totalSupply() external view returns (uint);
+    function balanceOf(address owner) external view returns (uint);
+    function allowance(address owner, address spender) external view returns (uint);
+
+    function approve(address spender, uint value) external returns (bool);
+    function transfer(address to, uint value) external returns (bool);
+    function transferFrom(address from, address to, uint value) external returns (bool);
+
+    function DOMAIN_SEPARATOR() external view returns (bytes32);
+    function PERMIT_TYPEHASH() external pure returns (bytes32);
+    function nonces(address owner) external view returns (uint);
+
+    function permit(address owner, address spender, uint value, uint deadline, uint8 v, bytes32 r, bytes32 s) external;
+}
+
+
+interface IUniswapV2Callee {
+    function uniswapV2Call(address sender, uint amount0, uint amount1, bytes calldata data) external;
+}

--- a/contracts/interfaces/IChainLinkOracle.sol
+++ b/contracts/interfaces/IChainLinkOracle.sol
@@ -7,7 +7,7 @@ interface IChainLinkOracle
     * @return int256 representing the latest answer of chainLink oracle.
     */
 	function latestAnswer() external view returns (int256);
-	
+	function decimals() external view returns (uint8);
 	function getRoundData(uint80 _roundId)
     external
     view

--- a/contracts/interfaces/IMarket.sol
+++ b/contracts/interfaces/IMarket.sol
@@ -30,7 +30,7 @@ contract IMarket {
 
     function marketCurrency() public view returns(bytes32);
 
-    function getMarketFeedData() public view returns(bytes32, address);
+    function getMarketFeedData() public view returns(uint8, bytes32, address);
 
     function settleMarket() external;
 

--- a/contracts/interfaces/IMarketUtility.sol
+++ b/contracts/interfaces/IMarketUtility.sol
@@ -30,6 +30,8 @@ contract IMarketUtility {
 
     function getAssetPriceUSD(address _currencyAddress) external view returns(uint latestAnswer);
     
+    function getPriceFeedDecimals(address _priceFeed) public view returns(uint8);
+
     function update() external;
     
     function calculatePredictionValue(uint[] memory params, address asset, address user, address marketFeedAddress, bool _checkMultiplier) public view returns(uint _predictionValue, bool _multiplierApplied);

--- a/contracts/interfaces/ITokenController.sol
+++ b/contracts/interfaces/ITokenController.sol
@@ -16,6 +16,8 @@ contract ITokenController {
         view
         returns (uint256 amount);
 
+    function transferFrom(address _token, address _of, address _to, uint256 amount) public;
+
     /**
      * @dev Returns tokens locked for a specified address for a
      *      specified reason at a specific time

--- a/contracts/mock/MockChainLinkAggregator.sol
+++ b/contracts/mock/MockChainLinkAggregator.sol
@@ -22,6 +22,9 @@ contract MockChainLinkAggregator is IChainLinkOracle{
       roundData[0] = RoundData(uint80(0),latestAns, updatedAt, updatedAt, uint80(0));
    }
 
+  function decimals() external view returns (uint8) {
+    return uint8(8);
+  }
 	/**
     * @dev Gets the latest answer of chainLink oracle.
     * @return int256 representing the latest answer of chainLink oracle.

--- a/contracts/mock/MockConfig.sol
+++ b/contracts/mock/MockConfig.sol
@@ -14,6 +14,10 @@ contract MockConfig is MarketUtility {
 		super.initialize(_addressParams);
 	}
 
+    function setWeth(address _weth) external {
+        weth = _weth;
+    }
+
 	function setPrice(uint _newPrice) external {
 		priceOfToken = _newPrice;
 	}

--- a/contracts/mock/MockMarketRegistry.sol
+++ b/contracts/mock/MockMarketRegistry.sol
@@ -4,24 +4,7 @@ import "../MarketRegistry.sol";
 
 contract MockMarketRegistry is MarketRegistry {
 
-	mapping(address => bytes32) marketId;
-  uint256 blockId;
-
-  function _initiateProvableQuery(uint256 _marketType, uint256 _marketCurrencyIndex, string memory _marketCreationHash, uint256 _gasLimit, address _previousMarket, uint256 _marketStartTime, uint256 _predictionTime) internal {
-    // bytes32 _oraclizeId = keccak256(abi.encodePacked(_marketType, _marketCurrencyIndex));
-    // // bool flag;
-    // marketOracleId[_oraclizeId] = MarketOraclize(_previousMarket, _marketType, _marketCurrencyIndex, _marketStartTime);
-    // marketTypeCurrencyOraclize[_marketType][_marketCurrencyIndex] = _oraclizeId;
-    // marketId[_previousMarket] = _oraclizeId;
-    // // if(marketOracleId[_oraclizeId].marketAddress == address(0)) {
-    // //   flag = true;
-    // // }
-    // if(_previousMarket  == address(0)) {
-    //   _createMarket(_marketType, _marketCurrencyIndex, 900000000000, 1000000000000, _marketStartTime);
-    // }
-  }
-
-  function getMarketOraclizeId(address _marketAddress) public view returns(bytes32){
-  	return marketId[_marketAddress];
+  function transferPlot(address payable _to, uint _amount) external {
+    _transferAsset(address(plotToken), _to, _amount);
   }
 }

--- a/contracts/mock/MockUniswapFactory.sol
+++ b/contracts/mock/MockUniswapFactory.sol
@@ -3,7 +3,12 @@ pragma solidity 0.5.7;
 
 contract MockUniswapFactory {
 
+  address public plotETHPair;
   function getPair(address tokenA, address tokenB) external view returns (address pair) {
-    return address(0);
+    return plotETHPair;
+  }
+
+  function setPair(address _plotETHPair) public {
+  	plotETHPair = _plotETHPair;
   }
 }

--- a/contracts/mock/MockUniswapV2Pair.sol
+++ b/contracts/mock/MockUniswapV2Pair.sol
@@ -1,0 +1,299 @@
+pragma solidity 0.5.7;
+
+import '../external/openzeppelin-solidity/math/Math.sol';
+import '../external/openzeppelin-solidity/math/SafeMath.sol';
+import '../external/uniswap/FixedPoint.sol';
+import '../external/uniswap/solidity-interface.sol';
+import '../interfaces/IToken.sol';
+
+
+contract UniswapV2ERC20 is IUniswapV2ERC20 {
+    using SafeMath for uint;
+
+    string public constant name = 'Uniswap V2';
+    string public constant symbol = 'UNI-V2';
+    uint8 public constant decimals = 18;
+    uint  public totalSupply;
+    mapping(address => uint) public balanceOf;
+    mapping(address => mapping(address => uint)) public allowance;
+
+    bytes32 public DOMAIN_SEPARATOR;
+    // keccak256("Permit(address owner,address spender,uint256 value,uint256 nonce,uint256 deadline)");
+    bytes32 public constant PERMIT_TYPEHASH = 0x6e71edae12b1b97f4d1f60370fef10105fa2faae0126114a169c64845d6126c9;
+    mapping(address => uint) public nonces;
+
+    event Approval(address indexed owner, address indexed spender, uint value);
+    event Transfer(address indexed from, address indexed to, uint value);
+
+    constructor() public {
+        uint chainId;
+        assembly {
+            chainId := 1
+        }
+        DOMAIN_SEPARATOR = keccak256(
+            abi.encode(
+                keccak256('EIP712Domain(string name,string version,uint256 chainId,address verifyingContract)'),
+                keccak256(bytes(name)),
+                keccak256(bytes('1')),
+                chainId,
+                address(this)
+            )
+        );
+    }
+
+    function _mint(address to, uint value) internal {
+        totalSupply = totalSupply.add(value);
+        balanceOf[to] = balanceOf[to].add(value);
+        emit Transfer(address(0), to, value);
+    }
+
+    function _burn(address from, uint value) internal {
+        balanceOf[from] = balanceOf[from].sub(value);
+        totalSupply = totalSupply.sub(value);
+        emit Transfer(from, address(0), value);
+    }
+
+    function _approve(address owner, address spender, uint value) private {
+        allowance[owner][spender] = value;
+        emit Approval(owner, spender, value);
+    }
+
+    function _transfer(address from, address to, uint value) private {
+        balanceOf[from] = balanceOf[from].sub(value);
+        balanceOf[to] = balanceOf[to].add(value);
+        emit Transfer(from, to, value);
+    }
+
+    function approve(address spender, uint value) external returns (bool) {
+        _approve(msg.sender, spender, value);
+        return true;
+    }
+
+    function transfer(address to, uint value) external returns (bool) {
+        _transfer(msg.sender, to, value);
+        return true;
+    }
+
+    function transferFrom(address from, address to, uint value) external returns (bool) {
+        if (allowance[from][msg.sender] != uint(-1)) {
+            allowance[from][msg.sender] = allowance[from][msg.sender].sub(value);
+        }
+        _transfer(from, to, value);
+        return true;
+    }
+
+    function permit(address owner, address spender, uint value, uint deadline, uint8 v, bytes32 r, bytes32 s) external {
+        require(deadline >= block.timestamp, 'UniswapV2: EXPIRED');
+        bytes32 digest = keccak256(
+            abi.encodePacked(
+                '\x19\x01',
+                DOMAIN_SEPARATOR,
+                keccak256(abi.encode(PERMIT_TYPEHASH, owner, spender, value, nonces[owner]++, deadline))
+            )
+        );
+        address recoveredAddress = ecrecover(digest, v, r, s);
+        require(recoveredAddress != address(0) && recoveredAddress == owner, 'UniswapV2: INVALID_SIGNATURE');
+        _approve(owner, spender, value);
+    }
+}
+
+contract MockUniswapV2Pair is IUniswapV2Pair, UniswapV2ERC20 {
+    using SafeMath  for uint;
+    using UQ112x112 for uint224;
+
+    uint public constant MINIMUM_LIQUIDITY = 10**3;
+    bytes4 private constant SELECTOR = bytes4(keccak256(bytes('transfer(address,uint256)')));
+
+    address public factory;
+    address public token0;
+    address public token1;
+
+    uint112 private reserve0;           // uses single storage slot, accessible via getReserves
+    uint112 private reserve1;           // uses single storage slot, accessible via getReserves
+    uint32  private blockTimestampLast; // uses single storage slot, accessible via getReserves
+
+    uint public price0CumulativeLast;
+    uint public price1CumulativeLast;
+    uint public kLast; // reserve0 * reserve1, as of immediately after the most recent liquidity event
+
+    uint private unlocked = 1;
+    modifier lock() {
+        require(unlocked == 1, 'UniswapV2: LOCKED');
+        unlocked = 0;
+        _;
+        unlocked = 1;
+    }
+
+    function getReserves() public view returns (uint112 _reserve0, uint112 _reserve1, uint32 _blockTimestampLast) {
+        _reserve0 = reserve0;
+        _reserve1 = reserve1;
+        _blockTimestampLast = blockTimestampLast;
+    }
+
+    function _safeTransfer(address token, address to, uint value) private {
+        (bool success, bytes memory data) = token.call(abi.encodeWithSelector(SELECTOR, to, value));
+        require(success && (data.length == 0 || abi.decode(data, (bool))), 'UniswapV2: TRANSFER_FAILED');
+    }
+
+    event Mint(address indexed sender, uint amount0, uint amount1);
+    event Burn(address indexed sender, uint amount0, uint amount1, address indexed to);
+    event Swap(
+        address indexed sender,
+        uint amount0In,
+        uint amount1In,
+        uint amount0Out,
+        uint amount1Out,
+        address indexed to
+    );
+    event Sync(uint112 reserve0, uint112 reserve1);
+
+    constructor() public {
+        factory = msg.sender;
+    }
+
+    // called once by the factory at time of deployment
+    function initialize(address _token0, address _token1) external {
+        require(msg.sender == factory, 'UniswapV2: FORBIDDEN'); // sufficient check
+        token0 = _token0;
+        token1 = _token1;
+    }
+
+    // update reserves and, on the first call per block, price accumulators
+    function _update(uint balance0, uint balance1, uint112 _reserve0, uint112 _reserve1) private {
+        require(balance0 <= uint112(-1) && balance1 <= uint112(-1), 'UniswapV2: OVERFLOW');
+        uint32 blockTimestamp = uint32(block.timestamp % 2**32);
+        uint32 timeElapsed = blockTimestamp - blockTimestampLast; // overflow is desired
+        if (timeElapsed > 0 && _reserve0 != 0 && _reserve1 != 0) {
+            // * never overflows, and + overflow is desired
+            price0CumulativeLast += uint(UQ112x112.encode(_reserve1).uqdiv(_reserve0)) * timeElapsed;
+            price1CumulativeLast += uint(UQ112x112.encode(_reserve0).uqdiv(_reserve1)) * timeElapsed;
+        }
+        reserve0 = uint112(balance0);
+        reserve1 = uint112(balance1);
+        blockTimestampLast = blockTimestamp;
+        emit Sync(reserve0, reserve1);
+    }
+
+    function sqrt(uint x) internal pure returns (uint y) {
+      uint z = (x + 1) / 2;
+      y = x;
+      while (z < y) {
+          y = z;
+          z = (x / z + z) / 2;
+      }
+    }
+
+    // if fee is on, mint liquidity equivalent to 1/6th of the growth in sqrt(k)
+    function _mintFee(uint112 _reserve0, uint112 _reserve1) private returns (bool feeOn) {
+        address feeTo = IUniswapV2Factory(factory).feeTo();
+        feeOn = feeTo != address(0);
+        uint _kLast = kLast; // gas savings
+        if (feeOn) {
+            if (_kLast != 0) {
+                uint rootK = sqrt(uint(_reserve0).mul(_reserve1));
+                uint rootKLast = sqrt(_kLast);
+                if (rootK > rootKLast) {
+                    uint numerator = totalSupply.mul(rootK.sub(rootKLast));
+                    uint denominator = rootK.mul(5).add(rootKLast);
+                    uint liquidity = numerator / denominator;
+                    if (liquidity > 0) _mint(feeTo, liquidity);
+                }
+            }
+        } else if (_kLast != 0) {
+            kLast = 0;
+        }
+    }
+
+    // this low-level function should be called from a contract which performs important safety checks
+    function mint(address to) external lock returns (uint liquidity) {
+        (uint112 _reserve0, uint112 _reserve1,) = getReserves(); // gas savings
+        uint balance0 = IToken(token0).balanceOf(address(this));
+        uint balance1 = IToken(token1).balanceOf(address(this));
+        uint amount0 = balance0.sub(_reserve0);
+        uint amount1 = balance1.sub(_reserve1);
+
+        bool feeOn = _mintFee(_reserve0, _reserve1);
+        uint _totalSupply = totalSupply; // gas savings, must be defined here since totalSupply can update in _mintFee
+        if (_totalSupply == 0) {
+            liquidity = sqrt(amount0.mul(amount1)).sub(MINIMUM_LIQUIDITY);
+           _mint(address(0), MINIMUM_LIQUIDITY); // permanently lock the first MINIMUM_LIQUIDITY tokens
+        } else {
+            liquidity = Math.min(amount0.mul(_totalSupply) / _reserve0, amount1.mul(_totalSupply) / _reserve1);
+        }
+        require(liquidity > 0, 'UniswapV2: INSUFFICIENT_LIQUIDITY_MINTED');
+        _mint(to, liquidity);
+
+        _update(balance0, balance1, _reserve0, _reserve1);
+        if (feeOn) kLast = uint(reserve0).mul(reserve1); // reserve0 and reserve1 are up-to-date
+        emit Mint(msg.sender, amount0, amount1);
+    }
+
+    // this low-level function should be called from a contract which performs important safety checks
+    function burn(address to) external lock returns (uint amount0, uint amount1) {
+        (uint112 _reserve0, uint112 _reserve1,) = getReserves(); // gas savings
+        address _token0 = token0;                                // gas savings
+        address _token1 = token1;                                // gas savings
+        uint balance0 = IToken(_token0).balanceOf(address(this));
+        uint balance1 = IToken(_token1).balanceOf(address(this));
+        uint liquidity = balanceOf[address(this)];
+
+        bool feeOn = _mintFee(_reserve0, _reserve1);
+        uint _totalSupply = totalSupply; // gas savings, must be defined here since totalSupply can update in _mintFee
+        amount0 = liquidity.mul(balance0) / _totalSupply; // using balances ensures pro-rata distribution
+        amount1 = liquidity.mul(balance1) / _totalSupply; // using balances ensures pro-rata distribution
+        require(amount0 > 0 && amount1 > 0, 'UniswapV2: INSUFFICIENT_LIQUIDITY_BURNED');
+        _burn(address(this), liquidity);
+        _safeTransfer(_token0, to, amount0);
+        _safeTransfer(_token1, to, amount1);
+        balance0 = IToken(_token0).balanceOf(address(this));
+        balance1 = IToken(_token1).balanceOf(address(this));
+
+        _update(balance0, balance1, _reserve0, _reserve1);
+        if (feeOn) kLast = uint(reserve0).mul(reserve1); // reserve0 and reserve1 are up-to-date
+        emit Burn(msg.sender, amount0, amount1, to);
+    }
+
+    // this low-level function should be called from a contract which performs important safety checks
+    function swap(uint amount0Out, uint amount1Out, address to, bytes calldata data) external lock {
+        require(amount0Out > 0 || amount1Out > 0, 'UniswapV2: INSUFFICIENT_OUTPUT_AMOUNT');
+        (uint112 _reserve0, uint112 _reserve1,) = getReserves(); // gas savings
+        require(amount0Out < _reserve0 && amount1Out < _reserve1, 'UniswapV2: INSUFFICIENT_LIQUIDITY');
+
+        uint balance0;
+        uint balance1;
+        { // scope for _token{0,1}, avoids stack too deep errors
+        address _token0 = token0;
+        address _token1 = token1;
+        require(to != _token0 && to != _token1, 'UniswapV2: INVALID_TO');
+        if (amount0Out > 0) _safeTransfer(_token0, to, amount0Out); // optimistically transfer tokens
+        if (amount1Out > 0) _safeTransfer(_token1, to, amount1Out); // optimistically transfer tokens
+        if (data.length > 0) IUniswapV2Callee(to).uniswapV2Call(msg.sender, amount0Out, amount1Out, data);
+        balance0 = IToken(_token0).balanceOf(address(this));
+        balance1 = IToken(_token1).balanceOf(address(this));
+        }
+        uint amount0In = balance0 > _reserve0 - amount0Out ? balance0 - (_reserve0 - amount0Out) : 0;
+        uint amount1In = balance1 > _reserve1 - amount1Out ? balance1 - (_reserve1 - amount1Out) : 0;
+        require(amount0In > 0 || amount1In > 0, 'UniswapV2: INSUFFICIENT_INPUT_AMOUNT');
+        { // scope for reserve{0,1}Adjusted, avoids stack too deep errors
+        uint balance0Adjusted = balance0.mul(1000).sub(amount0In.mul(3));
+        uint balance1Adjusted = balance1.mul(1000).sub(amount1In.mul(3));
+        require(balance0Adjusted.mul(balance1Adjusted) >= uint(_reserve0).mul(_reserve1).mul(1000**2), 'UniswapV2: K');
+        }
+
+        _update(balance0, balance1, _reserve0, _reserve1);
+        emit Swap(msg.sender, amount0In, amount1In, amount0Out, amount1Out, to);
+    }
+
+    // force balances to match reserves
+    function skim(address to) external lock {
+        address _token0 = token0; // gas savings
+        address _token1 = token1; // gas savings
+        _safeTransfer(_token0, to, IToken(_token0).balanceOf(address(this)).sub(reserve0));
+        _safeTransfer(_token1, to, IToken(_token1).balanceOf(address(this)).sub(reserve1));
+    }
+
+    // force reserves to match balances
+    function sync() external lock {
+        _update(IToken(token0).balanceOf(address(this)), IToken(token1).balanceOf(address(this)), reserve0, reserve1);
+    }
+}

--- a/contracts/mock/MockUtility.sol
+++ b/contracts/mock/MockUtility.sol
@@ -1,0 +1,9 @@
+pragma solidity 0.5.7;
+
+import "../MarketUtility.sol";
+
+contract MockMarketUtility is MarketUtility {
+    function setInitialCummulativePrice() public {
+        _setCummulativePrice();
+    }
+}

--- a/contracts/mock/MockWeth.sol
+++ b/contracts/mock/MockWeth.sol
@@ -1,0 +1,53 @@
+pragma solidity 0.5.7;
+
+
+contract MockWeth {
+    string public name     = "Wrapped Ether";
+    string public symbol   = "WETH";
+    uint8  public decimals = 18;
+
+    mapping (address => uint)                       public  balanceOf;
+    mapping (address => mapping (address => uint))  public  allowance;
+
+    function() external payable {
+        deposit();
+    }
+    function deposit() public payable {
+        balanceOf[msg.sender] += msg.value;
+    }
+    function withdraw(uint wad) public {
+        require(balanceOf[msg.sender] >= wad);
+        balanceOf[msg.sender] -= wad;
+        msg.sender.transfer(wad);
+    }
+
+    function totalSupply() public view returns (uint) {
+        return address(this).balance;
+    }
+
+    function approve(address guy, uint wad) public returns (bool) {
+        allowance[msg.sender][guy] = wad;
+        return true;
+    }
+
+    function transfer(address dst, uint wad) public returns (bool) {
+        return transferFrom(msg.sender, dst, wad);
+    }
+
+    function transferFrom(address src, address dst, uint wad)
+        public
+        returns (bool)
+    {
+        require(balanceOf[src] >= wad);
+
+        if (src != msg.sender && allowance[src][msg.sender] != uint(-1)) {
+            require(allowance[src][msg.sender] >= wad);
+            allowance[src][msg.sender] -= wad;
+        }
+
+        balanceOf[src] -= wad;
+        balanceOf[dst] += wad;
+
+        return true;
+    }
+}

--- a/migrations/2_deploy.js
+++ b/migrations/2_deploy.js
@@ -4,6 +4,7 @@ const Governance = artifacts.require('MockGovernance');
 const ProposalCategory = artifacts.require('ProposalCategory');
 const MemberRoles = artifacts.require('MemberRoles');
 const PlotusToken = artifacts.require('MockPLOT');
+const MockWeth = artifacts.require('MockWeth');
 const TokenController = artifacts.require('MockTokenController');
 const BLOT = artifacts.require('BLOT');
 const MarketConfig = artifacts.require('MockConfig');
@@ -38,6 +39,7 @@ module.exports = function(deployer, network, accounts){
       master = await Master.at(master.address);
       let implementations = [deployMemberRoles.address, deployProposalCategory.address, deployGovernance.address, deployPlotus.address, deployTokenController.address, blotToken.address];
       await master.initiateMaster(implementations, deployPlotusToken.address, accounts[0], marketConfig.address, [mockchainLinkAggregaror.address, uniswapRouter.address, deployPlotusToken.address, uniswapFactory.address], vestingContract.address);
+      let mockWeth = await deployer.deploy(MockWeth);
       let deployMarketBTC = await deployer.deploy(MarketBTC);
       let tc = await TokenController.at(await master.getLatestAddress("0x5443"));
       console.log(`Config: ${marketConfig.address}`);

--- a/scripts/startGanache.bat
+++ b/scripts/startGanache.bat
@@ -2,5 +2,5 @@
 echo Loading Resources . . .
 cd ../node_modules/.bin/
 echo starting ganche-cli  . . .
-start cmd.exe /k "ganache-cli --gasLimit 0xfffffffffff -i 5777 -p 8545 -m 'grocery obvious wire insane limit weather parade parrot patrol stock blast ivory' -a 47 -e 110 --gasPrice 0"
+start cmd.exe /k "ganache-cli --gasLimit 0xfffffffffff -i 5777 -k 'constantinople' -p 8545 -m 'grocery obvious wire insane limit weather parade parrot patrol stock blast ivory' -a 47 -e 110 --gasPrice 0"
 ping 127.0.0.1 -n 5 > nul

--- a/scripts/startGanache.sh
+++ b/scripts/startGanache.sh
@@ -2,5 +2,5 @@
 echo Loading Resources . . .
 cd ../node_modules/.bin/
 echo starting ganache-cli  . . .
-./ganache-cli --gasLimit 0xfffffffffff -i 5777 -p 8545 -m 'grocery obvious wire insane limit weather parade parrot patrol stock blast ivory' -a 47 -e 110 --gasPrice 0
+./ganache-cli --gasLimit 0xfffffffffff -i 5777 -k "constantinople" -p 8545 -m 'grocery obvious wire insane limit weather parade parrot patrol stock blast ivory' -a 47 -e 110 --gasPrice 0
 ping 127.0.0.1 -n 5 > nul

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -20,7 +20,7 @@ ganache_running() {
 }
 
 start_ganache() { 
-  node_modules/.bin/ganache-cli --gasLimit 85000000 -p "$ganache_port" -i 5777 -m "grocery obvious wire insane limit weather parade parrot patrol stock blast ivory" -a 47 -e 110 --gasPrice 0 > /dev/null &
+  node_modules/.bin/ganache-cli --gasLimit 85000000 -k "constantinople" -p "$ganache_port" -i 5777 -m "grocery obvious wire insane limit weather parade parrot patrol stock blast ivory" -a 47 -e 110 --gasPrice 0 > /dev/null &
   ganache_pid=$!
 }
 

--- a/test/01_hourlyMarketOptionPrice.js
+++ b/test/01_hourlyMarketOptionPrice.js
@@ -3,6 +3,7 @@ const OwnedUpgradeabilityProxy = artifacts.require("OwnedUpgradeabilityProxy");
 const Market = artifacts.require("MockMarket");
 const Plotus = artifacts.require("MarketRegistry");
 const Master = artifacts.require("Master");
+const TokenController = artifacts.require("TokenController");
 const PlotusToken = artifacts.require("MockPLOT");
 const MockchainLinkBTC = artifacts.require("MockChainLinkAggregator");
 const MarketConfig = artifacts.require("MockConfig");
@@ -20,6 +21,7 @@ contract("Market", async function([user1, user2, user3, user4, user5, user6, use
 		let BLOTInstance = await BLOT.deployed();
 		let MockchainLinkInstance = await MockchainLinkBTC.deployed();
 		let plotusNewAddress = await masterInstance.getLatestAddress(web3.utils.toHex("PL"));
+		tokenController  =await TokenController.at(await masterInstance.getLatestAddress(web3.utils.toHex("TC")));
 		let MockUniswapRouterInstance = await MockUniswapRouter.deployed();
 		let plotusNewInstance = await Plotus.at(plotusNewAddress);
 		let marketConfig = await plotusNewInstance.marketUtility();
@@ -97,6 +99,7 @@ contract("Market", async function([user1, user2, user3, user4, user5, user6, use
 		let BLOTInstance = await BLOT.deployed();
 		let MockchainLinkInstance = await MockchainLinkBTC.deployed();
 		let plotusNewAddress = await masterInstance.getLatestAddress(web3.utils.toHex("PL"));
+		tokenController  =await TokenController.at(await masterInstance.getLatestAddress(web3.utils.toHex("TC")));
 		let MockUniswapRouterInstance = await MockUniswapRouter.deployed();
 		let plotusNewInstance = await Plotus.at(plotusNewAddress);
 		let marketConfig = await plotusNewInstance.marketUtility();
@@ -122,7 +125,7 @@ contract("Market", async function([user1, user2, user3, user4, user5, user6, use
 		await MockUniswapRouterInstance.setPrice("12000000000000000");
 		await marketConfig.setPrice("12000000000000000");
 
-		await plotusToken.approve(marketInstance.address, "10000000000000000000000");
+		await plotusToken.approve(tokenController.address, "10000000000000000000000");
 		await marketInstance.placePrediction(plotusToken.address, "100000000000000000000", 1, 1, {
 			from: user1,
 		});
@@ -172,6 +175,7 @@ contract("Market", async function([user1, user2, user3, user4, user5, user6, use
 		let BLOTInstance = await BLOT.deployed();
 		let MockchainLinkInstance = await MockchainLinkBTC.deployed();
 		let plotusNewAddress = await masterInstance.getLatestAddress(web3.utils.toHex("PL"));
+		tokenController  =await TokenController.at(await masterInstance.getLatestAddress(web3.utils.toHex("TC")));
 		let MockUniswapRouterInstance = await MockUniswapRouter.deployed();
 		let plotusNewInstance = await Plotus.at(plotusNewAddress);
 		let marketConfig = await plotusNewInstance.marketUtility();
@@ -197,7 +201,7 @@ contract("Market", async function([user1, user2, user3, user4, user5, user6, use
 		await MockUniswapRouterInstance.setPrice("12000000000000000");
 		await marketConfig.setPrice("12000000000000000");
 
-		await plotusToken.approve(marketInstance.address, "10000000000000000000000");
+		await plotusToken.approve(tokenController.address, "10000000000000000000000");
 		await marketInstance.placePrediction(plotusToken.address, "1000000000000000000000", 1, 1, {
 			from: user1,
 		});
@@ -262,6 +266,7 @@ contract("Market", async function([user1, user2, user3, user4, user5, user6, use
 		let BLOTInstance = await BLOT.deployed();
 		let MockchainLinkInstance = await MockchainLinkBTC.deployed();
 		let plotusNewAddress = await masterInstance.getLatestAddress(web3.utils.toHex("PL"));
+		tokenController  =await TokenController.at(await masterInstance.getLatestAddress(web3.utils.toHex("TC")));
 		let MockUniswapRouterInstance = await MockUniswapRouter.deployed();
 		let plotusNewInstance = await Plotus.at(plotusNewAddress);
 		let marketConfig = await plotusNewInstance.marketUtility();
@@ -287,7 +292,7 @@ contract("Market", async function([user1, user2, user3, user4, user5, user6, use
 		await MockUniswapRouterInstance.setPrice("12000000000000000");
 		await marketConfig.setPrice("12000000000000000");
 
-		await plotusToken.approve(marketInstance.address, "10000000000000000000000");
+		await plotusToken.approve(tokenController.address, "10000000000000000000000");
 		await marketInstance.placePrediction(plotusToken.address, "1000000000000000000000", 1, 1, {
 			from: user1,
 		});
@@ -352,6 +357,7 @@ contract("Market", async function([user1, user2, user3, user4, user5, user6, use
 		let BLOTInstance = await BLOT.deployed();
 		let MockchainLinkInstance = await MockchainLinkBTC.deployed();
 		let plotusNewAddress = await masterInstance.getLatestAddress(web3.utils.toHex("PL"));
+		tokenController  =await TokenController.at(await masterInstance.getLatestAddress(web3.utils.toHex("TC")));
 		let MockUniswapRouterInstance = await MockUniswapRouter.deployed();
 		let plotusNewInstance = await Plotus.at(plotusNewAddress);
 		let marketConfig = await plotusNewInstance.marketUtility();
@@ -377,7 +383,7 @@ contract("Market", async function([user1, user2, user3, user4, user5, user6, use
 		await MockUniswapRouterInstance.setPrice("12000000000000000");
 		await marketConfig.setPrice("12000000000000000");
 
-		await plotusToken.approve(marketInstance.address, "10000000000000000000000");
+		await plotusToken.approve(tokenController.address, "10000000000000000000000");
 		await marketInstance.placePrediction(plotusToken.address, "1000000000000000000000", 1, 1, {
 			from: user1,
 		});
@@ -442,6 +448,7 @@ contract("Market", async function([user1, user2, user3, user4, user5, user6, use
 		let BLOTInstance = await BLOT.deployed();
 		let MockchainLinkInstance = await MockchainLinkBTC.deployed();
 		let plotusNewAddress = await masterInstance.getLatestAddress(web3.utils.toHex("PL"));
+		tokenController  =await TokenController.at(await masterInstance.getLatestAddress(web3.utils.toHex("TC")));
 		let MockUniswapRouterInstance = await MockUniswapRouter.deployed();
 		let plotusNewInstance = await Plotus.at(plotusNewAddress);
 		let marketConfig = await plotusNewInstance.marketUtility();
@@ -467,7 +474,7 @@ contract("Market", async function([user1, user2, user3, user4, user5, user6, use
 		await MockUniswapRouterInstance.setPrice("12000000000000000");
 		await marketConfig.setPrice("12000000000000000");
 
-		await plotusToken.approve(marketInstance.address, "10000000000000000000000");
+		await plotusToken.approve(tokenController.address, "10000000000000000000000");
 		await marketInstance.placePrediction(plotusToken.address, "1000000000000000000000", 1, 1, {
 			from: user1,
 		});
@@ -531,6 +538,7 @@ contract("Market", async function([user1, user2, user3, user4, user5, user6, use
 		let BLOTInstance = await BLOT.deployed();
 		let MockchainLinkInstance = await MockchainLinkBTC.deployed();
 		let plotusNewAddress = await masterInstance.getLatestAddress(web3.utils.toHex("PL"));
+		tokenController  =await TokenController.at(await masterInstance.getLatestAddress(web3.utils.toHex("TC")));
 		let MockUniswapRouterInstance = await MockUniswapRouter.deployed();
 		let plotusNewInstance = await Plotus.at(plotusNewAddress);
 		let marketConfig = await plotusNewInstance.marketUtility();
@@ -556,7 +564,7 @@ contract("Market", async function([user1, user2, user3, user4, user5, user6, use
 		await MockUniswapRouterInstance.setPrice("12000000000000000");
 		await marketConfig.setPrice("12000000000000000");
 
-		await plotusToken.approve(marketInstance.address, "10000000000000000000000");
+		await plotusToken.approve(tokenController.address, "10000000000000000000000");
 		await marketInstance.placePrediction(plotusToken.address, "1000000000000000000000", 1, 1, {
 			from: user1,
 		});
@@ -620,6 +628,7 @@ contract("Market", async function([user1, user2, user3, user4, user5, user6, use
 		let BLOTInstance = await BLOT.deployed();
 		let MockchainLinkInstance = await MockchainLinkBTC.deployed();
 		let plotusNewAddress = await masterInstance.getLatestAddress(web3.utils.toHex("PL"));
+		tokenController  =await TokenController.at(await masterInstance.getLatestAddress(web3.utils.toHex("TC")));
 		let MockUniswapRouterInstance = await MockUniswapRouter.deployed();
 		let plotusNewInstance = await Plotus.at(plotusNewAddress);
 		let marketConfig = await plotusNewInstance.marketUtility();
@@ -645,7 +654,7 @@ contract("Market", async function([user1, user2, user3, user4, user5, user6, use
 		await MockUniswapRouterInstance.setPrice("12000000000000000");
 		await marketConfig.setPrice("12000000000000000");
 
-		await plotusToken.approve(marketInstance.address, "10000000000000000000000");
+		await plotusToken.approve(tokenController.address, "10000000000000000000000");
 		await marketInstance.placePrediction(plotusToken.address, "1000000000000000000000", 1, 1, {
 			from: user1,
 		});

--- a/test/02_AirdropBlot.test.js
+++ b/test/02_AirdropBlot.test.js
@@ -7,6 +7,7 @@ const Master = artifacts.require("Master");
 const Airdrop = artifacts.require("Airdrop");
 const MarketConfig = artifacts.require("MockConfig");
 const PlotusToken = artifacts.require("MockPLOT");
+const TokenController = artifacts.require("TokenController");
 const BLOT = artifacts.require("BLOT");
 const MockUniswapRouter = artifacts.require("MockUniswapRouter");
 const BigNumber = require("bignumber.js");
@@ -29,6 +30,7 @@ contract("Airdrop", async function([user1, user2, user3, user4, user5, user6, us
 		BLOTInstance = await BLOT.at(await masterInstance.getLatestAddress(web3.utils.toHex("BL")));
 		MockUniswapRouterInstance = await MockUniswapRouter.deployed();
 		plotusNewAddress = await masterInstance.getLatestAddress(web3.utils.toHex("PL"));
+		tokenController  =await TokenController.at(await masterInstance.getLatestAddress(web3.utils.toHex("TC")));
 		plotusNewInstance = await Plotus.at(plotusNewAddress);
 		marketConfig = await plotusNewInstance.marketUtility();
 		marketConfig = await MarketConfig.at(marketConfig);
@@ -62,7 +64,7 @@ contract("Airdrop", async function([user1, user2, user3, user4, user5, user6, us
 		// set price lot
 		await MockUniswapRouterInstance.setPrice("1000000000000000");
 		await marketConfig.setPrice("1000000000000000");
-		await plotusToken.approve(openMarkets["_openMarkets"][0], "100000000000000000000", {
+		await plotusToken.approve(tokenController.address, "100000000000000000000", {
 			from: user1,
 		});
 		await marketInstance.placePrediction(plotusToken.address, "100000000000000000000", 2, 1, { from: user1 });
@@ -106,7 +108,7 @@ contract("Airdrop", async function([user1, user2, user3, user4, user5, user6, us
 		await MockUniswapRouterInstance.setPrice("1000000000000000");
 		await marketConfig.setPrice("1000000000000000");
 		await plotusToken.transfer(user3, "500000000000000000000");
-		await plotusToken.approve(openMarkets["_openMarkets"][0], "210000000000000000000", {
+		await plotusToken.approve(tokenController.address, "210000000000000000000", {
 			from: user3,
 		});
 

--- a/test/03_BasicGovernance.test.js
+++ b/test/03_BasicGovernance.test.js
@@ -69,8 +69,12 @@ contract("Governance", ([ab1, ab2, ab3, ab4, mem1, mem2, mem3, mem4, mem5, mem6,
     );
   });
 
-  it("Should not allow to add in AB if not member", async function () {
+  it("Should not allow to add in AB if not token holder", async function () {
     await assertRevert(mr.addInitialABandDRMembers([ab2, ab3, ab4], []));
+  });
+
+  it("Should not allow to add in DR if not token holder", async function () {
+    await assertRevert(mr.addInitialABandDRMembers([], [ab2, ab3, ab4]));
   });
 
   it("15.5 Should create a proposal", async function () {
@@ -289,6 +293,10 @@ contract("Governance", ([ab1, ab2, ab3, ab4, mem1, mem2, mem3, mem4, mem5, mem6,
     await gv.submitVote(pId, 1, {from:ab4});
     await increaseTime(604810);
     await gv.closeProposal(pId);
+  });
+
+  it("Should not allow to add in AB twice", async function () {
+    await assertRevert(mr.addInitialABandDRMembers([ab2, ab3, ab4], []));
   });
 
   it("Should reject action with AB", async function() {

--- a/test/04_dailyMarketOptionPrice.js
+++ b/test/04_dailyMarketOptionPrice.js
@@ -5,6 +5,7 @@ const Plotus = artifacts.require("MarketRegistry");
 const Master = artifacts.require("Master");
 const PlotusToken = artifacts.require("MockPLOT");
 const MarketConfig = artifacts.require("MockConfig");
+const TokenController = artifacts.require("TokenController");
 const MockchainLinkBTC = artifacts.require("MockChainLinkAggregator");
 const BLOT = artifacts.require("BLOT");
 const web3 = Market.web3;
@@ -19,6 +20,7 @@ contract("Market", async function([user1, user2, user3, user4, user5, user6, use
 		let BLOTInstance = await BLOT.deployed();
 		let MockchainLinkInstance = await MockchainLinkBTC.deployed();
 		let plotusNewAddress = await masterInstance.getLatestAddress(web3.utils.toHex("PL"));
+		tokenController  =await TokenController.at(await masterInstance.getLatestAddress(web3.utils.toHex("TC")));
 		let plotusNewInstance = await Plotus.at(plotusNewAddress);
 		let marketConfig = await plotusNewInstance.marketUtility();
 		marketConfig = await MarketConfig.at(marketConfig);
@@ -84,6 +86,7 @@ contract("Market", async function([user1, user2, user3, user4, user5, user6, use
 		let BLOTInstance = await BLOT.deployed();
 		let MockchainLinkInstance = await MockchainLinkBTC.deployed();
 		let plotusNewAddress = await masterInstance.getLatestAddress(web3.utils.toHex("PL"));
+		tokenController  =await TokenController.at(await masterInstance.getLatestAddress(web3.utils.toHex("TC")));
 		let plotusNewInstance = await Plotus.at(plotusNewAddress);
 		let marketConfig = await plotusNewInstance.marketUtility();
 		marketConfig = await MarketConfig.at(marketConfig);
@@ -115,7 +118,7 @@ contract("Market", async function([user1, user2, user3, user4, user5, user6, use
 		// await marketConfig.setKYCComplianceStatus(user4, true);
 		// await marketConfig.setKYCComplianceStatus(user5, true);
 
-		await plotusToken.approve(marketInstance.address, "10000000000000000000000");
+		await plotusToken.approve(tokenController.address, "10000000000000000000000");
 		await marketInstance.placePrediction(plotusToken.address, "100000000000000000000", 1, 1, {
 			from: user1,
 		});
@@ -158,6 +161,7 @@ contract("Market", async function([user1, user2, user3, user4, user5, user6, use
 		let BLOTInstance = await BLOT.deployed();
 		let MockchainLinkInstance = await MockchainLinkBTC.deployed();
 		let plotusNewAddress = await masterInstance.getLatestAddress(web3.utils.toHex("PL"));
+		tokenController  =await TokenController.at(await masterInstance.getLatestAddress(web3.utils.toHex("TC")));
 		let plotusNewInstance = await Plotus.at(plotusNewAddress);
 		let marketConfig = await plotusNewInstance.marketUtility();
 		marketConfig = await MarketConfig.at(marketConfig);
@@ -189,7 +193,7 @@ contract("Market", async function([user1, user2, user3, user4, user5, user6, use
 		// await marketConfig.setKYCComplianceStatus(user4, true);
 		// await marketConfig.setKYCComplianceStatus(user5, true);
 
-		await plotusToken.approve(marketInstance.address, "10000000000000000000000");
+		await plotusToken.approve(tokenController.address, "10000000000000000000000");
 		await marketInstance.placePrediction(plotusToken.address, "100000000000000000000", 1, 1, {
 			from: user1,
 		});
@@ -247,6 +251,7 @@ contract("Market", async function([user1, user2, user3, user4, user5, user6, use
 		let BLOTInstance = await BLOT.deployed();
 		let MockchainLinkInstance = await MockchainLinkBTC.deployed();
 		let plotusNewAddress = await masterInstance.getLatestAddress(web3.utils.toHex("PL"));
+		tokenController  =await TokenController.at(await masterInstance.getLatestAddress(web3.utils.toHex("TC")));
 		let plotusNewInstance = await Plotus.at(plotusNewAddress);
 		let marketConfig = await plotusNewInstance.marketUtility();
 		marketConfig = await MarketConfig.at(marketConfig);
@@ -278,7 +283,7 @@ contract("Market", async function([user1, user2, user3, user4, user5, user6, use
 		// await marketConfig.setKYCComplianceStatus(user4, true);
 		// await marketConfig.setKYCComplianceStatus(user5, true);
 
-		await plotusToken.approve(marketInstance.address, "10000000000000000000000");
+		await plotusToken.approve(tokenController.address, "10000000000000000000000");
 		await marketInstance.placePrediction(plotusToken.address, "100000000000000000000", 1, 1, {
 			from: user1,
 		});
@@ -336,6 +341,7 @@ contract("Market", async function([user1, user2, user3, user4, user5, user6, use
 		let BLOTInstance = await BLOT.deployed();
 		let MockchainLinkInstance = await MockchainLinkBTC.deployed();
 		let plotusNewAddress = await masterInstance.getLatestAddress(web3.utils.toHex("PL"));
+		tokenController  =await TokenController.at(await masterInstance.getLatestAddress(web3.utils.toHex("TC")));
 		let plotusNewInstance = await Plotus.at(plotusNewAddress);
 		let marketConfig = await plotusNewInstance.marketUtility();
 		marketConfig = await MarketConfig.at(marketConfig);
@@ -367,7 +373,7 @@ contract("Market", async function([user1, user2, user3, user4, user5, user6, use
 		// await marketConfig.setKYCComplianceStatus(user4, true);
 		// await marketConfig.setKYCComplianceStatus(user5, true);
 
-		await plotusToken.approve(marketInstance.address, "10000000000000000000000");
+		await plotusToken.approve(tokenController.address, "10000000000000000000000");
 		await marketInstance.placePrediction(plotusToken.address, "1000000000000000000000", 1, 1, {
 			from: user1,
 		});
@@ -425,6 +431,7 @@ contract("Market", async function([user1, user2, user3, user4, user5, user6, use
 		let BLOTInstance = await BLOT.deployed();
 		let MockchainLinkInstance = await MockchainLinkBTC.deployed();
 		let plotusNewAddress = await masterInstance.getLatestAddress(web3.utils.toHex("PL"));
+		tokenController  =await TokenController.at(await masterInstance.getLatestAddress(web3.utils.toHex("TC")));
 		let plotusNewInstance = await Plotus.at(plotusNewAddress);
 		let marketConfig = await plotusNewInstance.marketUtility();
 		marketConfig = await MarketConfig.at(marketConfig);
@@ -456,7 +463,7 @@ contract("Market", async function([user1, user2, user3, user4, user5, user6, use
 		// await marketConfig.setKYCComplianceStatus(user4, true);
 		// await marketConfig.setKYCComplianceStatus(user5, true);
 
-		await plotusToken.approve(marketInstance.address, "10000000000000000000000");
+		await plotusToken.approve(tokenController.address, "10000000000000000000000");
 		await marketInstance.placePrediction(plotusToken.address, "1000000000000000000000", 1, 1, {
 			from: user1,
 		});

--- a/test/05_disputeResolution.js
+++ b/test/05_disputeResolution.js
@@ -77,15 +77,15 @@ contract("Market", ([ab1, ab2, ab3, ab4, dr1, dr2, dr3, notMember]) => {
     let userBalBefore = await plotusToken.balanceOf(ab1);
     console.log("balance before accept proposal",userBalBefore/1)
     
-    await plotusToken.approve(tokenController.address, "100000000000000000000000");
+    await plotusToken.approve(tokenController.address, "100000000000000000000000",{from : dr1});
     await tokenController.lock("0x4452","20000000000000000000000",(86400*20),{from : dr1});
     
-    await plotusToken.approve(tokenController.address, "100000000000000000000000");
+    await plotusToken.approve(tokenController.address, "100000000000000000000000",{from : dr2});
     await tokenController.lock("0x4452","20000000000000000000000",(86400*20),{from : dr2});
 
     await assertRevert(gv.submitVote(proposalId, 1, {from:dr3})) //reverts as tokens not locked
   
-    await plotusToken.approve(tokenController.address, "100000000000000000000000");
+    await plotusToken.approve(tokenController.address, "100000000000000000000000",{from : dr3});
     await tokenController.lock("0x4452","20000000000000000000000",(86400*20),{from : dr3});
     await gv.submitVote(proposalId, 1, {from:dr1});
     await gv.submitVote(proposalId, 1, {from:dr2});
@@ -155,13 +155,13 @@ contract("Market", ([ab1, ab2, ab3, ab4, dr1, dr2, dr3, notMember]) => {
     console.log("proposalId",proposalId/1)
     let userBalBefore = await plotusToken.balanceOf(ab1);
     console.log("balance before reject proposal",userBalBefore/1)
-    await plotusToken.approve(tokenController.address, "100000000000000000000000");
+    await plotusToken.approve(tokenController.address, "100000000000000000000000",{from : dr1});
     await tokenController.lock("0x4452","5000000000000000000000",(86400*20),{from : dr1});
     
-    await plotusToken.approve(tokenController.address, "100000000000000000000000");
+    await plotusToken.approve(tokenController.address, "100000000000000000000000",{from : dr2});
     await tokenController.lock("0x4452","5000000000000000000000",(86400*20),{from : dr2});
     
-    await plotusToken.approve(tokenController.address, "100000000000000000000000");
+    await plotusToken.approve(tokenController.address, "100000000000000000000000",{from : dr3});
     await tokenController.lock("0x4452","5000000000000000000000",(86400*100),{from : dr3});
     await gv.submitVote(proposalId, 0, {from:dr1});
     await gv.submitVote(proposalId, 0, {from:dr2});

--- a/test/05_disputeResolution.js
+++ b/test/05_disputeResolution.js
@@ -51,21 +51,21 @@ contract("Market", ([ab1, ab2, ab3, ab4, dr1, dr2, dr3, notMember]) => {
     await mr.addInitialABandDRMembers([ab2, ab3, ab4], [dr1, dr2, dr3], { from: ab1 });
     
     // cannot raise dispute if market is open
-    await plotusToken.approve(marketInstance.address, "10000000000000000000000");
+    await plotusToken.approve(tokenController.address, "10000000000000000000000");
     await assertRevert(marketInstance.raiseDispute(1400000000000,"raise dispute","this is description","this is solution hash"));
     
     await increaseTime(3601);
     // cannot raise dispute if market is closed but result is not out
-    await plotusToken.approve(marketInstance.address, "10000000000000000000000");
+    await plotusToken.approve(tokenController.address, "10000000000000000000000");
     await assertRevert(marketInstance.raiseDispute(1400000000000,"raise dispute","this is description","this is solution hash"));
    
     await increaseTime(3600);
     await marketInstance.calculatePredictionResult(100000000000);
      // cannot raise dispute with less than minimum stake
-    await plotusToken.approve(marketInstance.address, "10000000000000000000000");
+    await plotusToken.approve(tokenController.address, "10000000000000000000000");
     await assertRevert(marketInstance.raiseDispute(1400000000000,"raise dispute","this is description","this is solution hash",{from : notMember}));
     //can raise dispute in cooling period and stake
-    await plotusToken.approve(marketInstance.address, "10000000000000000000000");
+    await plotusToken.approve(tokenController.address, "10000000000000000000000");
     await marketInstance.raiseDispute(1400000000000,"raise dispute","this is description","this is solution hash");
     // cannot raise dispute multiple times
     await assertRevert(marketInstance.raiseDispute(1400000000000,"raise dispute","this is description","this is solution hash"));
@@ -141,11 +141,11 @@ contract("Market", ([ab1, ab2, ab3, ab4, dr1, dr2, dr3, notMember]) => {
     await increaseTime(7201);
     await marketInstance.calculatePredictionResult(100000000000);
     //can raise dispute in cooling period and stake
-    await plotusToken.approve(marketInstance.address, "10000000000000000000000");
+    await plotusToken.approve(tokenController.address, "10000000000000000000000");
     await marketInstance.raiseDispute(1400000000000,"raise dispute","this is description","this is solution hash");
     await increaseTime(901);
      // cannot raise dispute if market cool time is over
-    await plotusToken.approve(marketInstance.address, "10000000000000000000000");
+    await plotusToken.approve(tokenController.address, "10000000000000000000000");
     await assertRevert(marketInstance.raiseDispute(1400000000000,"raise dispute","this is description","this is solution hash"));
     
     let plotusContractBalanceBefore = await plotusToken.balanceOf(plotusNewInstance.address);

--- a/test/05_disputeResolution.js
+++ b/test/05_disputeResolution.js
@@ -205,7 +205,7 @@ contract("Market", ([ab1, ab2, ab3, ab4, dr1, dr2, dr3, notMember]) => {
     await gv.closeProposal(p);
     let proposal = await gv.proposal(p);
     assert.equal(proposal[2].toNumber(), 3);
-    await increaseTime(3601);
+    await increaseTime(86400);
     await gv.triggerAction(p);
     let proposalActionStatus = await gv.proposalActionStatus(p);
     assert.equal(proposalActionStatus/1, 3, "Not executed");
@@ -237,7 +237,7 @@ contract("Market", ([ab1, ab2, ab3, ab4, dr1, dr2, dr3, notMember]) => {
     await gv.closeProposal(p);
     let proposal = await gv.proposal(p);
     assert.equal(proposal[2].toNumber(), 3);
-    await increaseTime(3601);
+    await increaseTime(86400);
     await gv.triggerAction(p);
     let proposalActionStatus = await gv.proposalActionStatus(p);
     assert.equal(proposalActionStatus/1, 3, "Not executed");
@@ -271,7 +271,7 @@ contract("Market", ([ab1, ab2, ab3, ab4, dr1, dr2, dr3, notMember]) => {
     await gv.closeProposal(p);
     let proposal = await gv.proposal(p);
     assert.equal(proposal[2].toNumber(), 3);
-    await increaseTime(3601);
+    await increaseTime(86400);
     await gv.triggerAction(p);
     let proposalActionStatus = await gv.proposalActionStatus(p);
     assert.equal(proposalActionStatus/1, 1, "Not executed");

--- a/test/05_disputeResolution.js
+++ b/test/05_disputeResolution.js
@@ -69,11 +69,6 @@ contract("Market", ([ab1, ab2, ab3, ab4, dr1, dr2, dr3, notMember]) => {
     await marketInstance.raiseDispute(1400000000000,"raise dispute","this is description","this is solution hash");
     // cannot raise dispute multiple times
     await assertRevert(marketInstance.raiseDispute(1400000000000,"raise dispute","this is description","this is solution hash"));
-    await increaseTime(901);
-     // cannot raise dispute if market cool time is over
-    await plotusToken.approve(marketInstance.address, "10000000000000000000000");
-    await assertRevert(marketInstance.raiseDispute(1400000000000,"raise dispute","this is description","this is solution hash"));
-    
     await assertRevert(marketInstance.resolveDispute(true, 100));
     let winningOption_af = await marketInstance.getMarketResults()
     console.log("winningOption",winningOption_af[0]/1)
@@ -148,6 +143,11 @@ contract("Market", ([ab1, ab2, ab3, ab4, dr1, dr2, dr3, notMember]) => {
     //can raise dispute in cooling period and stake
     await plotusToken.approve(marketInstance.address, "10000000000000000000000");
     await marketInstance.raiseDispute(1400000000000,"raise dispute","this is description","this is solution hash");
+    await increaseTime(901);
+     // cannot raise dispute if market cool time is over
+    await plotusToken.approve(marketInstance.address, "10000000000000000000000");
+    await assertRevert(marketInstance.raiseDispute(1400000000000,"raise dispute","this is description","this is solution hash"));
+    
     let plotusContractBalanceBefore = await plotusToken.balanceOf(plotusNewInstance.address);
     let winningOption_before = await marketInstance.getMarketResults()
     console.log("winningOption",winningOption_before[0]/1)

--- a/test/06_GovernanceCategory.test.js
+++ b/test/06_GovernanceCategory.test.js
@@ -283,6 +283,12 @@ contract('Configure Global Parameters', accounts => {
         assert.equal(plbalEth - plbalEthAfter, toWei(10));
         assert.equal(userbalEthAfter/1e18 - userbalEth/1e18, 10);
       });
+
+      it('Should not allow create a proposal in category raiseDispute directly', async function() {
+        let p = await gv.getProposalLength();
+        await gv.createProposal("proposal", "proposal", "proposal", 0);
+        await assertRevert(gv.categorizeProposal(p, 10, 0));
+      });
       
       it('Should Whitelist sponsor', async function() {
 

--- a/test/09_multiplier.js
+++ b/test/09_multiplier.js
@@ -40,8 +40,8 @@ describe("1. Players are incentivized to stake DAO tokens to earn a multiplier o
 			await marketConfig.setOptionPrice(1, 9);
 			await marketConfig.setOptionPrice(2, 18);
 			await marketConfig.setOptionPrice(3, 27);
-			await plotusToken.approve(marketInstance.address, "10000000000000000000000");
-			await plotusToken.approve(marketInstance.address, "10000000000000000000000", { from: user2 });
+			await plotusToken.approve(tokenController.address, "10000000000000000000000");
+			await plotusToken.approve(tokenController.address, "10000000000000000000000", { from: user2 });
 
 			// await marketConfig.setAMLComplianceStatus(user1, true);
 			// await marketConfig.setKYCComplianceStatus(user1, true);
@@ -62,15 +62,15 @@ describe("1. Players are incentivized to stake DAO tokens to earn a multiplier o
 			await marketInstance.placePrediction(plotusToken.address, "400000000000000000000", 2, 2, {
 				from: user2,
 			});
-			await plotusToken.approve(marketInstance.address, "10000000000000000000000", { from: user3 });
+			await plotusToken.approve(tokenController.address, "10000000000000000000000", { from: user3 });
 			await marketInstance.placePrediction(plotusToken.address, "100000000000000000000", 1, 3, {
 				from: user3,
 			});
-			await plotusToken.approve(marketInstance.address, "10000000000000000000000", { from: user4 });
+			await plotusToken.approve(tokenController.address, "10000000000000000000000", { from: user4 });
 			await marketInstance.placePrediction(plotusToken.address, "100000000000000000000", 3, 4, {
 				from: user4,
 			});
-			await plotusToken.approve(marketInstance.address, "10000000000000000000000", { from: user5 });
+			await plotusToken.approve(tokenController.address, "10000000000000000000000", { from: user5 });
 			await marketInstance.placePrediction(plotusToken.address, "10000000000000000000", 3, 4, {
 				from: user5,
 			});
@@ -128,23 +128,23 @@ describe("1. Players are incentivized to stake DAO tokens to earn a multiplier o
 			await marketConfig.setOptionPrice(2, 18);
 			await marketConfig.setOptionPrice(3, 27);
 
-			await plotusToken.approve(marketInstance.address, "10000000000000000000000");
+			await plotusToken.approve(tokenController.address, "10000000000000000000000");
 			await marketInstance.placePrediction(plotusToken.address, "100000000000000000000", 2, 1, {
 				from: user1,
 			});
-			await plotusToken.approve(marketInstance.address, "10000000000000000000000", { from: user2 });
+			await plotusToken.approve(tokenController.address, "10000000000000000000000", { from: user2 });
 			await marketInstance.placePrediction(plotusToken.address, "400000000000000000000", 2, 2, {
 				from: user2,
 			});
-			await plotusToken.approve(marketInstance.address, "10000000000000000000000", { from: user3 });
+			await plotusToken.approve(tokenController.address, "10000000000000000000000", { from: user3 });
 			await marketInstance.placePrediction(plotusToken.address, "100000000000000000000", 1, 3, {
 				from: user3,
 			});
-			await plotusToken.approve(marketInstance.address, "10000000000000000000000", { from: user4 });
+			await plotusToken.approve(tokenController.address, "10000000000000000000000", { from: user4 });
 			await marketInstance.placePrediction(plotusToken.address, "100000000000000000000", 3, 4, {
 				from: user4,
 			});
-			await plotusToken.approve(marketInstance.address, "10000000000000000000000", { from: user5 });
+			await plotusToken.approve(tokenController.address, "10000000000000000000000", { from: user5 });
 			await marketInstance.placePrediction(plotusToken.address, "10000000000000000000", 3, 4, {
 				from: user5,
 			});
@@ -382,9 +382,9 @@ describe("3. Multiple Option predictions", () => {
 			await marketConfig.setOptionPrice(2, 18);
 			await marketConfig.setOptionPrice(3, 27);
 
-			await plotusToken.approve(marketInstance.address, web3.utils.toWei("500"));
-			await plotusToken.approve(marketInstance.address, web3.utils.toWei("500"), { from: user2 });
-			await plotusToken.approve(marketInstance.address, web3.utils.toWei("500"), { from: user3 });
+			await plotusToken.approve(tokenController.address, web3.utils.toWei("500"));
+			await plotusToken.approve(tokenController.address, web3.utils.toWei("500"), { from: user2 });
+			await plotusToken.approve(tokenController.address, web3.utils.toWei("500"), { from: user3 });
 		});
 
 		it("3.1. Scenario 1 ", async () => {
@@ -453,9 +453,9 @@ describe("3. Multiple Option predictions", () => {
 			await marketConfig.setOptionPrice(2, 18);
 			await marketConfig.setOptionPrice(3, 27);
 
-			await plotusToken.approve(marketInstance.address, web3.utils.toWei("500"));
-			await plotusToken.approve(marketInstance.address, web3.utils.toWei("500"), { from: user2 });
-			await plotusToken.approve(marketInstance.address, web3.utils.toWei("500"), { from: user3 });
+			await plotusToken.approve(tokenController.address, web3.utils.toWei("500"));
+			await plotusToken.approve(tokenController.address, web3.utils.toWei("500"), { from: user2 });
+			await plotusToken.approve(tokenController.address, web3.utils.toWei("500"), { from: user3 });
 		});
 
 		it("3.2. Scenario 2", async () => {
@@ -523,9 +523,9 @@ describe("3. Multiple Option predictions", () => {
 			await marketConfig.setOptionPrice(2, 18);
 			await marketConfig.setOptionPrice(3, 27);
 
-			await plotusToken.approve(marketInstance.address, web3.utils.toWei("500"));
-			await plotusToken.approve(marketInstance.address, web3.utils.toWei("500"), { from: user2 });
-			await plotusToken.approve(marketInstance.address, web3.utils.toWei("500"), { from: user3 });
+			await plotusToken.approve(tokenController.address, web3.utils.toWei("500"));
+			await plotusToken.approve(tokenController.address, web3.utils.toWei("500"), { from: user2 });
+			await plotusToken.approve(tokenController.address, web3.utils.toWei("500"), { from: user3 });
 		});
 
 		it("3.3. Scenario 3 ", async () => {
@@ -595,9 +595,9 @@ describe("3. Multiple Option predictions", () => {
 			await marketConfig.setOptionPrice(2, 18);
 			await marketConfig.setOptionPrice(3, 27);
 
-			await plotusToken.approve(marketInstance.address, web3.utils.toWei("500"));
-			await plotusToken.approve(marketInstance.address, web3.utils.toWei("500"), { from: user2 });
-			await plotusToken.approve(marketInstance.address, web3.utils.toWei("500"), { from: user3 });
+			await plotusToken.approve(tokenController.address, web3.utils.toWei("500"));
+			await plotusToken.approve(tokenController.address, web3.utils.toWei("500"), { from: user2 });
+			await plotusToken.approve(tokenController.address, web3.utils.toWei("500"), { from: user3 });
 		});
 
 		it("3.4. Scenario 4", async () => {
@@ -710,9 +710,9 @@ describe("3. Multiple Option predictions", () => {
 			await marketConfig.setOptionPrice(2, 18);
 			await marketConfig.setOptionPrice(3, 27);
 
-			await plotusToken.approve(marketInstance.address, web3.utils.toWei("500"));
-			await plotusToken.approve(marketInstance.address, web3.utils.toWei("500"), { from: user2 });
-			await plotusToken.approve(marketInstance.address, web3.utils.toWei("500"), { from: user3 });
+			await plotusToken.approve(tokenController.address, web3.utils.toWei("500"));
+			await plotusToken.approve(tokenController.address, web3.utils.toWei("500"), { from: user2 });
+			await plotusToken.approve(tokenController.address, web3.utils.toWei("500"), { from: user3 });
 		});
 
 		it("3.5. Scenario 5", async () => {
@@ -819,9 +819,9 @@ describe("4. New cases", () => {
 			await marketConfig.setOptionPrice(2, 18);
 			await marketConfig.setOptionPrice(3, 27);
 
-			await plotusToken.approve(marketInstance.address, web3.utils.toWei("500"));
-			await plotusToken.approve(marketInstance.address, web3.utils.toWei("500"), { from: user2 });
-			await plotusToken.approve(marketInstance.address, web3.utils.toWei("500"), { from: user3 });
+			await plotusToken.approve(tokenController.address, web3.utils.toWei("500"));
+			await plotusToken.approve(tokenController.address, web3.utils.toWei("500"), { from: user2 });
+			await plotusToken.approve(tokenController.address, web3.utils.toWei("500"), { from: user3 });
 		});
 
 		it("Multiple Market claim, scenario 6,7,8", async () => {
@@ -863,9 +863,9 @@ describe("4. New cases", () => {
 			// let marketStartTime = parseFloat((await marketInstance.marketData())[0]);
             // console.log("marketStartTime", marketStartTime)
 			// console.log(await latestTime());
-			await plotusToken.approve(marketInstance.address, web3.utils.toWei("500"));
-			await plotusToken.approve(marketInstance.address, web3.utils.toWei("500"), { from: user2 });
-			await plotusToken.approve(marketInstance.address, web3.utils.toWei("500"), { from: user3 });
+			await plotusToken.approve(tokenController.address, web3.utils.toWei("500"));
+			await plotusToken.approve(tokenController.address, web3.utils.toWei("500"), { from: user2 });
+			await plotusToken.approve(tokenController.address, web3.utils.toWei("500"), { from: user3 });
 			await marketInstance.placePrediction(plotusToken.address, web3.utils.toWei("100"), 1, 1, { from: user1 });
 			await marketInstance.placePrediction("0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE", web3.utils.toWei("4"), 2, 2, {
 				from: user1,
@@ -903,9 +903,9 @@ describe("4. New cases", () => {
 			await marketConfig.setOptionPrice(1, 9);
 			await marketConfig.setOptionPrice(2, 18);
 			await marketConfig.setOptionPrice(3, 27);            
-            await plotusToken.approve(marketInstance.address, web3.utils.toWei("500"));
-			await plotusToken.approve(marketInstance.address, web3.utils.toWei("500"), { from: user2 });
-			await plotusToken.approve(marketInstance.address, web3.utils.toWei("500"), { from: user3 });
+            await plotusToken.approve(tokenController.address, web3.utils.toWei("500"));
+			await plotusToken.approve(tokenController.address, web3.utils.toWei("500"), { from: user2 });
+			await plotusToken.approve(tokenController.address, web3.utils.toWei("500"), { from: user3 });
             await marketInstance.placePrediction(plotusToken.address, web3.utils.toWei("100"), 1, 1, { from: user1 });
 			await marketInstance.placePrediction("0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE", web3.utils.toWei("4"), 2, 2, {
 				from: user1,

--- a/test/09_multiplier.js
+++ b/test/09_multiplier.js
@@ -109,15 +109,19 @@ describe("1. Players are incentivized to stake DAO tokens to earn a multiplier o
 			// await marketInstance.setMockPriceFlag(false);
 			await increaseTime(10001);
 			assert.ok(marketInstance);
-			await plotusToken.approve(tokenController.address, "10000000000000000000000");
+			await plotusToken.approve(tokenController.address, "10000000000000000000000", { from: user1 });
 			await tokenController.lock("0x534d", "1100000000000000000000", 86400 * 30, { from: user1 });
 			await plotusToken.transfer(user2, "2500000000000000000000");
+			await plotusToken.approve(tokenController.address, "10000000000000000000000", { from: user2 });
 			await tokenController.lock("0x534d", "1600000000000000000000", 86400 * 30, { from: user2 });
 			await plotusToken.transfer(user3, "2500000000000000000000");
+			await plotusToken.approve(tokenController.address, "10000000000000000000000", { from: user3 });
 			await tokenController.lock("0x534d", "1100000000000000000000", 86400 * 30, { from: user3 });
 			await plotusToken.transfer(user4, "2500000000000000000000");
+			await plotusToken.approve(tokenController.address, "10000000000000000000000", { from: user4 });
 			await tokenController.lock("0x534d", "1100000000000000000000", 86400 * 30, { from: user4 });
 			await plotusToken.transfer(user5, "2500000000000000000000");
+			await plotusToken.approve(tokenController.address, "10000000000000000000000", { from: user5 });
 			await tokenController.lock("0x534d", "1100", 86400 * 30, { from: user5 });
 
 			await marketConfig.setOptionPrice(1, 9);
@@ -283,18 +287,23 @@ describe("2. Place prediction with ETH and check multiplier ", () => {
 			await marketConfig.setOptionPrice(3, 27);
 		});
 		it("2.2", async () => {
+			await plotusToken.approve(tokenController.address, "1000000000000000000000000", { from: user1 });
 			await tokenController.lock("0x534d", web3.utils.toWei("110000"), 86400 * 30, { from: user1 });
 
 			await plotusToken.transfer(user2, web3.utils.toWei("1000"));
+			await plotusToken.approve(tokenController.address, "1000000000000000000000000", { from: user2 });
 			await tokenController.lock("0x534d", web3.utils.toWei("1000"), 86400 * 30, { from: user2 });
 
 			await plotusToken.transfer(user3, web3.utils.toWei("100000"));
+			await plotusToken.approve(tokenController.address, "1000000000000000000000000", { from: user3 });
 			await tokenController.lock("0x534d", web3.utils.toWei("100000"), 86400 * 30, { from: user3 });
 
 			await plotusToken.transfer(user4, web3.utils.toWei("200000"));
+			await plotusToken.approve(tokenController.address, "1000000000000000000000000", { from: user4 });
 			await tokenController.lock("0x534d", web3.utils.toWei("200000"), 86400 * 30, { from: user4 });
 
 			await plotusToken.transfer(user5, web3.utils.toWei("11000"));
+			await plotusToken.approve(tokenController.address, "1000000000000000000000000", { from: user5 });
 			await tokenController.lock("0x534d", web3.utils.toWei("11000"), 86400 * 30, { from: user5 });
 
 			await marketInstance.placePrediction("0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE", web3.utils.toWei("10"), 1, 4, {

--- a/test/10_plotus.js
+++ b/test/10_plotus.js
@@ -76,10 +76,10 @@ contract("Market", async function([user1, user2, user3, user4, user5, user6, use
 
 		it("0.1 Assert values from getData()", async () => {
 			assert.equal(option1RangeMIN, 0);
-			assert.equal(option1RangeMAX, 925649804322);
-			assert.equal(option2RangeMIN, 925649804323);
-			assert.equal(option2RangeMAX, 944349800369);
-			assert.equal(option3RangeMIX, 944349800370);
+			assert.equal(option1RangeMAX, 932699999999);
+			assert.equal(option2RangeMIN, 932700000000);
+			assert.equal(option2RangeMAX, 937400000000);
+			assert.equal(option3RangeMIX, 937400000001);
 			assert.equal(option3RangeMAX, 1.157920892373162e77);
 			assert.equal(parseFloat(marketData._optionPrice[0]), priceOption1);
 			assert.equal(parseFloat(marketData._optionPrice[1]), priceOption2);

--- a/test/10_plotus.js
+++ b/test/10_plotus.js
@@ -137,28 +137,6 @@ contract("Market", async function([user1, user2, user3, user4, user5, user6, use
 				from: user2,
 			});
 			await marketInstance.placePrediction(plotusToken.address, "400000000000000000000", 2, 2, { from: user2 });
-			// await plotusToken.approve(BLOTInstance.address, "1000000000000000000000");
-			// await BLOTInstance.mint(user2, "1000000000000000000000");
-			// // await BLOTInstance.transferFrom(user1, user2, "500000000000000000000", {
-			// //   from: user1,
-			// // });
-
-			// await BLOTInstance.approve(
-			//   openMarkets["_openMarkets"][0],
-			//   "40000000000000000000",
-			//   {
-			//     from: user2,
-			//   }
-			// );
-			// console.log(await BLOTInstance.balanceOf(user1));
-			// await BLOTInstance.addMinter(marketInstance.address);
-			// await marketInstance.placePrediction(
-			//   BLOTInstance.address,
-			//   "40000000000000000000",
-			//   2,
-			//   5,
-			//   { from: user2 }
-			// );
 
 			// user 3
 			await MockUniswapRouterInstance.setPrice("1000000000000000");
@@ -169,21 +147,6 @@ contract("Market", async function([user1, user2, user3, user4, user5, user6, use
 			});
 			await marketInstance.placePrediction(plotusToken.address, "210000000000000000000", 2, 2, { from: user3 });
 			// user 4
-			// place predictions with ether
-			// await BLOTInstance.approve(
-			//   openMarkets["_openMarkets"][0],
-			//   "123000000000000000000",
-			//   {
-			//     from: user4,
-			//   }
-			// );
-			// await marketInstance.placePrediction(
-			//   BLOTInstance.address,
-			//   "123000000000000000000",
-			//   3,
-			//   5,
-			//   { from: user4 }
-			// );
 
 			await MockUniswapRouterInstance.setPrice("15000000000000000");
 			await marketConfig.setPrice("15000000000000000");
@@ -276,28 +239,13 @@ contract("Market", async function([user1, user2, user3, user4, user5, user6, use
 				36.98149537,
 				721.7363059,
 			];
-			// console.log("prediction points for user 1");
-			// PredictionPointsUser1 = await getPredictionPoints(accounts[0], options[0]);
-			// PredictionPointsUser3 = await getPredictionPoints(accounts[2], options[2]);
-
-			// console.log(
-			//   `prediction points : ${PredictionPointsUser1} expected : ${PredictionPointsExpected[0]} `
-			// );
-			// console.log("prediction points for user 3");
-			// console.log(
-			//   `prediction points : ${PredictionPointsUser3} expected : ${PredictionPointsExpected[2]} `
-			// );
 
 			for (let index = 0; index < 10; index++) {
 				let PredictionPoints = await getPredictionPoints(accounts[index], options[index]);
 				PredictionPoints = PredictionPoints / 1000;
 				PredictionPoints = PredictionPoints.toFixed(1);
 				await assert(PredictionPoints === PredictionPointsExpected[index].toFixed(1));
-				// commented by parv (added a assert above)
-				// console.log(`user${index + 1} : option : ${options[index]}  `);
-				// console.log(`prediction points : ${PredictionPoints} expected : ${PredictionPointsExpected[index].toFixed(1)} `);
 			}
-			// console.log(await plotusToken.balanceOf(user1));
 		});
 
 		it("1.1 Assert values from getData() prediction status before", async () => {
@@ -356,11 +304,6 @@ contract("Market", async function([user1, user2, user3, user4, user5, user6, use
 			lotBalanceBefore = await plotusToken.balanceOf(openMarkets["_openMarkets"][0]);	
 			assert.equal(parseFloat(plotusBalanceBefore).toFixed(3), (0.010).toFixed(3));
 			assert.equal(parseFloat(web3.utils.fromWei(lotBalanceBefore)).toFixed(2), (832.5835).toFixed(2));
-			// commented by parv (added a assert above)
-			// console.log(`plotus eth balance before commision : ${plotusBalanceBefore}`);
-			// lotBalanceBefore = lotBalanceBefore / 1;
-			// console.log(`Lot Balance of market before commision : ${lotBalanceBefore}`);
-			// lot supply , lot balance of market
 			await MockUniswapRouterInstance.setPrice("1000000000000000");
 			await marketConfig.setPrice("1000000000000000");
 			await increaseTime(360001);
@@ -373,11 +316,6 @@ contract("Market", async function([user1, user2, user3, user4, user5, user6, use
 				parseFloat(web3.utils.fromWei(String(parseFloat(lotBalanceAfter) - parseFloat(lotBalanceBefore)))).toFixed(2),
 				(0).toFixed(2)
 			);
-			// commented by parv (added a assert above)
-			// console.log(`plotus balance after commision : ${plotusBalanceAfter}`);
-			// lotBalanceAfter = lotBalanceAfter / 1;
-			// console.log(`Lot Balance of market before commision : ${lotBalanceAfter}`);
-			// console.log(`Difference : ${lotBalanceAfter - lotBalanceBefore}`);
 		});
 
 		it("2.check total return for each user prediction values in eth", async () => {
@@ -392,13 +330,10 @@ contract("Market", async function([user1, user2, user3, user4, user5, user6, use
 
 			const returnInEthExpected = [0, 0, 0, 0, 1.851161356, 5.141838644, 0.5994, 1.1988, 0.7992, 0.3996];
 			// calulate  rewards for every user in eth
-			// console.log("Rewards in Eth");
 
 			for (let index = 0; index < 10; index++) {
 				// check eth returns
 				let returns = await getReturnsInEth(accounts[index]);
-				// commented by parv as already added assert
-				// console.log(`return : ${returns} Expected :${returnInEthExpected[index]}`);
 				assert.equal(parseFloat(returns).toFixed(2), returnInEthExpected[index].toFixed(2));
 			}
 		});
@@ -426,10 +361,6 @@ contract("Market", async function([user1, user2, user3, user4, user5, user6, use
 				diffToken = diffToken.toFixed(1);
 				expectedInLot = totalReturnLotExpexted[accounts.indexOf(account)].toFixed(1);
 				assert.equal(diffToken, expectedInLot);
-				// commented by parv (as already added assert above)
-				// console.log(`User ${accounts.indexOf(account) + 1}`);
-				// console.log(`Returned in Eth : ${diff}  Expected : ${expectedInEth} `);
-				// console.log(`Returned in Lot : ${diffToken}  Expected : ${expectedInLot} `);
 			}
 		});
 		// it("4. Market should have 0 balance after all claims", async () => {

--- a/test/10_plotus.js
+++ b/test/10_plotus.js
@@ -78,10 +78,10 @@ contract("Market", async function([user1, user2, user3, user4, user5, user6, use
 
 		it("0.1 Assert values from getData()", async () => {
 			assert.equal(option1RangeMIN, 0);
-			assert.equal(option1RangeMAX, 932699999999);
-			assert.equal(option2RangeMIN, 932700000000);
-			assert.equal(option2RangeMAX, 937400000000);
-			assert.equal(option3RangeMIX, 937400000001);
+			assert.equal(option1RangeMAX, 934999999999);
+			assert.equal(option2RangeMIN, 935000000000);
+			assert.equal(option2RangeMAX, 937500000000);
+			assert.equal(option3RangeMIX, 937500000001);
 			assert.equal(option3RangeMAX, 1.157920892373162e77);
 			assert.equal(parseFloat(marketData._optionPrice[0]), priceOption1);
 			assert.equal(parseFloat(marketData._optionPrice[1]), priceOption2);

--- a/test/10_plotus.js
+++ b/test/10_plotus.js
@@ -7,6 +7,7 @@ const Master = artifacts.require("Master");
 const MarketConfig = artifacts.require("MockConfig");
 const PlotusToken = artifacts.require("MockPLOT");
 const Governance = artifacts.require("Governance");
+const TokenController = artifacts.require("TokenController");
 const MockchainLinkBTC = artifacts.require("MockChainLinkAggregator");
 const BLOT = artifacts.require("BLOT");
 const MockUniswapRouter = artifacts.require("MockUniswapRouter");
@@ -43,6 +44,7 @@ contract("Market", async function([user1, user2, user3, user4, user5, user6, use
 			BLOTInstance = await BLOT.deployed();
 			MockUniswapRouterInstance = await MockUniswapRouter.deployed();
 			plotusNewAddress = await masterInstance.getLatestAddress(web3.utils.toHex("PL"));
+			tokenController  =await TokenController.at(await masterInstance.getLatestAddress(web3.utils.toHex("TC")));
 			governance = await masterInstance.getLatestAddress(web3.utils.toHex("GV"));
 			governance = await Governance.at(governance);
 			plotusNewInstance = await Plotus.at(plotusNewAddress);
@@ -121,7 +123,7 @@ contract("Market", async function([user1, user2, user3, user4, user5, user6, use
 			// set price lot
 			await MockUniswapRouterInstance.setPrice("1000000000000000");
 			await marketConfig.setPrice("1000000000000000");
-			await plotusToken.approve(openMarkets["_openMarkets"][0], "100000000000000000000", {
+			await plotusToken.approve(tokenController.address, "100000000000000000000", {
 				from: user1,
 			});
 			await marketInstance.placePrediction(plotusToken.address, "100000000000000000000", 2, 1, { from: user1 });
@@ -131,7 +133,7 @@ contract("Market", async function([user1, user2, user3, user4, user5, user6, use
 			await marketConfig.setPrice("2000000000000000");
 			await plotusToken.transfer(user2, "500000000000000000000");
 
-			await plotusToken.approve(openMarkets["_openMarkets"][0], "400000000000000000000", {
+			await plotusToken.approve(tokenController.address, "400000000000000000000", {
 				from: user2,
 			});
 			await marketInstance.placePrediction(plotusToken.address, "400000000000000000000", 2, 2, { from: user2 });
@@ -162,7 +164,7 @@ contract("Market", async function([user1, user2, user3, user4, user5, user6, use
 			await MockUniswapRouterInstance.setPrice("1000000000000000");
 			await marketConfig.setPrice("1000000000000000");
 			await plotusToken.transfer(user3, "500000000000000000000");
-			await plotusToken.approve(openMarkets["_openMarkets"][0], "210000000000000000000", {
+			await plotusToken.approve(tokenController.address, "210000000000000000000", {
 				from: user3,
 			});
 			await marketInstance.placePrediction(plotusToken.address, "210000000000000000000", 2, 2, { from: user3 });
@@ -188,7 +190,7 @@ contract("Market", async function([user1, user2, user3, user4, user5, user6, use
 
 			await plotusToken.transfer(user4, "200000000000000000000");
 
-			await plotusToken.approve(openMarkets["_openMarkets"][0], "123000000000000000000", {
+			await plotusToken.approve(tokenController.address, "123000000000000000000", {
 				from: user4,
 			});
 			await marketInstance.placePrediction(plotusToken.address, "123000000000000000000", 3, 3, { from: user4 });
@@ -331,7 +333,7 @@ contract("Market", async function([user1, user2, user3, user4, user5, user6, use
 
 		it("Raise dispute and reject", async() => {
 			await plotusToken.transfer(user11, "200000000000000000000");
-			await plotusToken.approve(marketInstance.address, "100000000000000000000", {
+			await plotusToken.approve(tokenController.address, "100000000000000000000", {
 				from: user11,
 			});
 			let proposalId = await governance.getProposalLength();

--- a/test/11_plotus2.js
+++ b/test/11_plotus2.js
@@ -25,6 +25,7 @@ contract("Market", async function([user1, user2, user3, user4, user5, user6, use
 		BLOTInstance = await BLOT.deployed();
 		MockUniswapRouterInstance = await MockUniswapRouter.deployed();
 		plotusNewAddress = await masterInstance.getLatestAddress(web3.utils.toHex("PL"));
+		tokenController  =await TokenController.at(await masterInstance.getLatestAddress(web3.utils.toHex("TC")));
 		plotusNewInstance = await Plotus.at(plotusNewAddress);
 		marketConfig = await plotusNewInstance.marketUtility();
 		marketConfig = await MarketConfig.at(marketConfig);
@@ -47,7 +48,7 @@ contract("Market", async function([user1, user2, user3, user4, user5, user6, use
 		// set price lot
 		await MockUniswapRouterInstance.setPrice("1000000000000000");
 		await marketConfig.setPrice("1000000000000000");
-		await plotusToken.approve(openMarkets["_openMarkets"][0], "100000000000000000000", {
+		await plotusToken.approve(tokenController.address, "100000000000000000000", {
 			from: user1,
 		});
 		await marketInstance.placePrediction(plotusToken.address, "100000000000000000000", 2, 1, { from: user1 });
@@ -57,7 +58,7 @@ contract("Market", async function([user1, user2, user3, user4, user5, user6, use
 		await marketConfig.setPrice("2000000000000000");
 		await plotusToken.transfer(user2, "500000000000000000000");
 
-		await plotusToken.approve(openMarkets["_openMarkets"][0], "400000000000000000000", {
+		await plotusToken.approve(tokenController.address, "400000000000000000000", {
 			from: user2,
 		});
 		await marketInstance.placePrediction(plotusToken.address, "400000000000000000000", 2, 2, { from: user2 });
@@ -65,7 +66,7 @@ contract("Market", async function([user1, user2, user3, user4, user5, user6, use
 		await MockUniswapRouterInstance.setPrice("1000000000000000");
 		await marketConfig.setPrice("1000000000000000");
 		await plotusToken.transfer(user3, "500000000000000000000");
-		await plotusToken.approve(openMarkets["_openMarkets"][0], "210000000000000000000", {
+		await plotusToken.approve(tokenController.address, "210000000000000000000", {
 			from: user3,
 		});
 		await marketInstance.placePrediction(plotusToken.address, "210000000000000000000", 2, 2, { from: user3 });
@@ -74,7 +75,7 @@ contract("Market", async function([user1, user2, user3, user4, user5, user6, use
 
 		await plotusToken.transfer(user4, "200000000000000000000");
 
-		await plotusToken.approve(openMarkets["_openMarkets"][0], "123000000000000000000", {
+		await plotusToken.approve(tokenController.address, "123000000000000000000", {
 			from: user4,
 		});
 		await marketInstance.placePrediction(plotusToken.address, "123000000000000000000", 3, 3, { from: user4 });
@@ -281,7 +282,7 @@ contract("Raise Dispute and accpet the dispute", async function([user1, user2, u
 		// set price lot
 		await MockUniswapRouterInstance.setPrice("1000000000000000");
 		await marketConfig.setPrice("1000000000000000");
-		await plotusToken.approve(openMarkets["_openMarkets"][0], "100000000000000000000", {
+		await plotusToken.approve(tokenController.address, "100000000000000000000", {
 			from: user1,
 		});
 		await marketInstance.placePrediction(plotusToken.address, "100000000000000000000", 2, 1, { from: user1 });
@@ -291,7 +292,7 @@ contract("Raise Dispute and accpet the dispute", async function([user1, user2, u
 		await marketConfig.setPrice("2000000000000000");
 		await plotusToken.transfer(user2, "500000000000000000000");
 
-		await plotusToken.approve(openMarkets["_openMarkets"][0], "400000000000000000000", {
+		await plotusToken.approve(tokenController.address, "400000000000000000000", {
 			from: user2,
 		});
 		await marketInstance.placePrediction(plotusToken.address, "400000000000000000000", 2, 2, { from: user2 });
@@ -299,7 +300,7 @@ contract("Raise Dispute and accpet the dispute", async function([user1, user2, u
 		await MockUniswapRouterInstance.setPrice("1000000000000000");
 		await marketConfig.setPrice("1000000000000000");
 		await plotusToken.transfer(user3, "500000000000000000000");
-		await plotusToken.approve(openMarkets["_openMarkets"][0], "210000000000000000000", {
+		await plotusToken.approve(tokenController.address, "210000000000000000000", {
 			from: user3,
 		});
 		await marketInstance.placePrediction(plotusToken.address, "210000000000000000000", 2, 2, { from: user3 });
@@ -308,7 +309,7 @@ contract("Raise Dispute and accpet the dispute", async function([user1, user2, u
 
 		await plotusToken.transfer(user4, "200000000000000000000");
 
-		await plotusToken.approve(openMarkets["_openMarkets"][0], "123000000000000000000", {
+		await plotusToken.approve(tokenController.address, "123000000000000000000", {
 			from: user4,
 		});
 		await marketInstance.placePrediction(plotusToken.address, "123000000000000000000", 3, 3, { from: user4 });
@@ -408,7 +409,7 @@ contract("Raise Dispute and accpet the dispute", async function([user1, user2, u
 
 	it("Raise dispute, accept, change the winninOption to 3", async() => {
 			await plotusToken.transfer(user11, "200000000000000000000");
-			await plotusToken.approve(marketInstance.address, "100000000000000000000", {
+			await plotusToken.approve(tokenController.address, "100000000000000000000", {
 				from: user11,
 			});
 			let proposalId = await governance.getProposalLength();

--- a/test/11_plotus2.js
+++ b/test/11_plotus2.js
@@ -252,14 +252,14 @@ contract("Raise Dispute and accpet the dispute", async function([user1, user2, u
 		await plotusToken.transfer(dr2, "20000000000000000000000");
 		await plotusToken.transfer(dr3, "20000000000000000000000");
 		await mr.addInitialABandDRMembers([dr1], [dr1, dr2, dr3]);
-		await plotusToken.approve(tokenController.address, "20000000000000000000000");
+		await plotusToken.approve(tokenController.address, "20000000000000000000000",{from : dr1});
 	    await tokenController.lock("0x4452","20000000000000000000000",(86400*20),{from : dr1});
 	    
-	    await plotusToken.approve(tokenController.address, "20000000000000000000000");
+	    await plotusToken.approve(tokenController.address, "20000000000000000000000",{from : dr2});
 	    await tokenController.lock("0x4452","20000000000000000000000",(86400*20),{from : dr2});
 
 	  
-	    await plotusToken.approve(tokenController.address, "20000000000000000000000");
+	    await plotusToken.approve(tokenController.address, "20000000000000000000000",{from : dr3});
 	    await tokenController.lock("0x4452","20000000000000000000000",(86400*20),{from : dr3});
 	    
 		// console.log(await plotusNewInstance.getOpenMarkets());

--- a/test/12_plotus3.js
+++ b/test/12_plotus3.js
@@ -6,6 +6,7 @@ const Master = artifacts.require("Master");
 const MarketConfig = artifacts.require("MockConfig");
 const PlotusToken = artifacts.require("MockPLOT");
 const BLOT = artifacts.require("BLOT");
+const TokenController = artifacts.require("TokenController");
 const MockUniswapRouter = artifacts.require("MockUniswapRouter");
 const BigNumber = require("bignumber.js");
 
@@ -22,6 +23,7 @@ contract("Market", async function([user1, user2, user3, user4, user5, user6, use
 		BLOTInstance = await BLOT.deployed();
 		MockUniswapRouterInstance = await MockUniswapRouter.deployed();
 		plotusNewAddress = await masterInstance.getLatestAddress(web3.utils.toHex("PL"));
+		tokenController  =await TokenController.at(await masterInstance.getLatestAddress(web3.utils.toHex("TC")));
 		plotusNewInstance = await Plotus.at(plotusNewAddress);
 		marketConfig = await plotusNewInstance.marketUtility();
 		marketConfig = await MarketConfig.at(marketConfig);
@@ -44,7 +46,7 @@ contract("Market", async function([user1, user2, user3, user4, user5, user6, use
 		// set price lot
 		await MockUniswapRouterInstance.setPrice("1000000000000000");
 		await marketConfig.setPrice("1000000000000000");
-		await plotusToken.approve(openMarkets["_openMarkets"][0], "100000000000000000000", {
+		await plotusToken.approve(tokenController.address, "100000000000000000000", {
 			from: user1,
 		});
 		await marketInstance.placePrediction(plotusToken.address, "100000000000000000000", 1, 1, { from: user1 });
@@ -54,7 +56,7 @@ contract("Market", async function([user1, user2, user3, user4, user5, user6, use
 		await marketConfig.setPrice("2000000000000000");
 		await plotusToken.transfer(user2, "500000000000000000000");
 
-		await plotusToken.approve(openMarkets["_openMarkets"][0], "400000000000000000000", {
+		await plotusToken.approve(tokenController.address, "400000000000000000000", {
 			from: user2,
 		});
 		await marketInstance.placePrediction(plotusToken.address, "400000000000000000000", 1, 2, { from: user2 });
@@ -62,7 +64,7 @@ contract("Market", async function([user1, user2, user3, user4, user5, user6, use
 		await MockUniswapRouterInstance.setPrice("1000000000000000");
 		await marketConfig.setPrice("1000000000000000");
 		await plotusToken.transfer(user3, "500000000000000000000");
-		await plotusToken.approve(openMarkets["_openMarkets"][0], "210000000000000000000", {
+		await plotusToken.approve(tokenController.address, "210000000000000000000", {
 			from: user3,
 		});
 		await marketInstance.placePrediction(plotusToken.address, "210000000000000000000", 1, 2, { from: user3 });
@@ -71,7 +73,7 @@ contract("Market", async function([user1, user2, user3, user4, user5, user6, use
 
 		await plotusToken.transfer(user4, "200000000000000000000");
 
-		await plotusToken.approve(openMarkets["_openMarkets"][0], "123000000000000000000", {
+		await plotusToken.approve(tokenController.address, "123000000000000000000", {
 			from: user4,
 		});
 		await marketInstance.placePrediction(plotusToken.address, "123000000000000000000", 1, 3, { from: user4 });

--- a/test/13_PlotusToken.test.js
+++ b/test/13_PlotusToken.test.js
@@ -63,7 +63,6 @@ contract("PlotusToken", ([owner, account2, account3]) => {
 			await assertRevert(plotusToken.changeOperator(account3, { from: account2 }));
 			await assertRevert(plotusToken.mint(account2, 1000, { from: account2 }));
 			await plotusToken.transfer(account2, web3.utils.toWei("5"), { from: owner }); //ownerBalance - 5
-			await assertRevert(plotusToken.operatorTransfer(account2, web3.utils.toWei("5"), { from: account3 }));
 			await assertRevert(plotusToken.lockForGovernanceVote(account2, 10, { from: account2 }));
 		});
 	});

--- a/test/14_plotusWithBlot.js
+++ b/test/14_plotusWithBlot.js
@@ -7,6 +7,7 @@ const Master = artifacts.require("Master");
 const MarketConfig = artifacts.require("MockConfig");
 const PlotusToken = artifacts.require("MockPLOT");
 const BLOT = artifacts.require("BLOT");
+const TokenController = artifacts.require("TokenController");
 const MockUniswapRouter = artifacts.require("MockUniswapRouter");
 const BigNumber = require("bignumber.js");
 
@@ -24,6 +25,7 @@ contract("Market", async function([user1, user2, user3, user4, user5, user6, use
 		BLOTInstance = await BLOT.at(await masterInstance.getLatestAddress(web3.utils.toHex("BL")));
 		MockUniswapRouterInstance = await MockUniswapRouter.deployed();
 		plotusNewAddress = await masterInstance.getLatestAddress(web3.utils.toHex("PL"));
+		tokenController  =await TokenController.at(await masterInstance.getLatestAddress(web3.utils.toHex("TC")));
 		plotusNewInstance = await Plotus.at(plotusNewAddress);
 		marketConfig = await plotusNewInstance.marketUtility();
 		marketConfig = await MarketConfig.at(marketConfig);
@@ -48,7 +50,7 @@ contract("Market", async function([user1, user2, user3, user4, user5, user6, use
 		// set price lot
 		await MockUniswapRouterInstance.setPrice("1000000000000000");
 		await marketConfig.setPrice("1000000000000000");
-		await plotusToken.approve(openMarkets["_openMarkets"][0], "100000000000000000000", {
+		await plotusToken.approve(tokenController.address, "100000000000000000000", {
 			from: user1,
 		});
 		await marketInstance.placePrediction(plotusToken.address, "100000000000000000000", 2, 1, { from: user1 });
@@ -91,7 +93,7 @@ contract("Market", async function([user1, user2, user3, user4, user5, user6, use
 		await MockUniswapRouterInstance.setPrice("1000000000000000");
 		await marketConfig.setPrice("1000000000000000");
 		await plotusToken.transfer(user3, "500000000000000000000");
-		await plotusToken.approve(openMarkets["_openMarkets"][0], "210000000000000000000", {
+		await plotusToken.approve(tokenController.address, "210000000000000000000", {
 			from: user3,
 		});
 

--- a/test/15_plotx.test.js
+++ b/test/15_plotx.test.js
@@ -55,7 +55,7 @@ contract("PlotX", ([ab1, ab2, ab3, ab4, mem1, mem2, mem3, mem4, mem5, mem6, mem7
 		marketConfig = await pl.marketUtility();
 		marketConfig = await MarketConfig.at(marketConfig);
 		MockUniswapRouterInstance = await MockUniswapRouter.deployed();
-		tc = await TokenController.at(await nxms.getLatestAddress(toHex("MR")));
+		tc = await TokenController.at(await nxms.getLatestAddress(toHex("TC")));
 		await assertRevert(pl.setMasterAddress());
 		// try {
 		// 	await (gv.setMasterAddress());
@@ -146,11 +146,12 @@ contract("PlotX", ([ab1, ab2, ab3, ab4, mem1, mem2, mem3, mem4, mem5, mem6, mem7
 		// set price lot
 		await MockUniswapRouterInstance.setPrice("1000000000000000");
 		await marketConfig.setPrice("1000000000000000");
-		await plotusToken.approve(openMarkets["_openMarkets"][2], "18000000000000000000000000");
+		await plotusToken.approve(tc.address, "18000000000000000000000000");
 		await marketInstance.claimReturn(ab1);
 		await assertRevert(marketInstance.placePrediction(plotusToken.address, "10000000000000000000", 9, 1));
 		await assertRevert(marketInstance.placePrediction(ab1, "10000000000000000000", 9, 1));
-		await plotusToken.approve(marketInstance.address, "18000000000000000000000000", {from:mem1});
+		await plotusToken.approve(tc.address, "18000000000000000000000000", {from:mem1});
+		await plotusToken.approve(tc.address, "18000000000000000000000000");
 		await assertRevert(marketInstance.sponsorIncentives(plotusToken.address, "1000000000000000000", {from:mem1}));
 		await marketInstance.sponsorIncentives(plotusToken.address, "1000000000000000000");
 		await assertRevert(marketInstance.sponsorIncentives(plotusToken.address, "1000000000000000000"));
@@ -233,7 +234,7 @@ contract("PlotX", ([ab1, ab2, ab3, ab4, mem1, mem2, mem3, mem4, mem5, mem6, mem7
 		// set price lot
 		await MockUniswapRouterInstance.setPrice("1000000000000000");
 		await marketConfig.setPrice("1000000000000000");
-		await plotusToken.approve(openMarkets["_openMarkets"][9], "100000000000000000000");
+		await plotusToken.approve(tc.address, "100000000000000000000");
 		await marketInstance.estimatePredictionValue(1, "10000000000000000000", 1);
 		await marketInstance.placePrediction(plotusToken.address, "10000000000000000000", 1, 1);
 		let reward = await marketInstance.getReturn(ab1);

--- a/test/15_plotx.test.js
+++ b/test/15_plotx.test.js
@@ -153,7 +153,7 @@ contract("PlotX", ([ab1, ab2, ab3, ab4, mem1, mem2, mem3, mem4, mem5, mem6, mem7
 		await plotusToken.approve(marketInstance.address, "18000000000000000000000000", {from:mem1});
 		await assertRevert(marketInstance.sponsorIncentives(plotusToken.address, "1000000000000000000", {from:mem1}));
 		await marketInstance.sponsorIncentives(plotusToken.address, "1000000000000000000");
-		await assertRevert(marketInstance.sponsorIncentives(plotusToken.address, "1000000000000000000", {from:mem1}));
+		await assertRevert(marketInstance.sponsorIncentives(plotusToken.address, "1000000000000000000"));
 		await marketInstance.placePrediction(plotusToken.address, "1000000000000000000000", 1, 1);
 		let totalStaked = await pl.getTotalAssetStakedByUser(ab1);
 		assert.equal(totalStaked[0]/1, "1000000000000000000000");
@@ -164,7 +164,7 @@ contract("PlotX", ([ab1, ab2, ab3, ab4, mem1, mem2, mem3, mem4, mem5, mem6, mem7
 		await increaseTime(604810);
 		await marketInstance.claimReturn(ab1);
 		await marketInstance.calculatePredictionResult(1);
-		await assertRevert(marketInstance.sponsorIncentives(plotusToken.address, "1000000000000000000", {from:mem1}));
+		await assertRevert(marketInstance.sponsorIncentives(plotusToken.address, "1000000000000000000"));
 		await assertRevert(marketInstance.placePrediction(plotusToken.address, "10000000000000000000", 1, 1));
 		await assertRevert(marketInstance.calculatePredictionResult(0));
 		await marketInstance.claimReturn(ab1);

--- a/test/16_ProposalCategory.test.js
+++ b/test/16_ProposalCategory.test.js
@@ -106,7 +106,7 @@ contract("Proposal Category", function ([owner, other]) {
 		await assertRevert(pc.editCategory(c1, "Yo", 1, 1, 0, [1], 1, "", nullAddress, toHex("EX"), [0, 0, 0], ""));
 		//proposal to update category
 		let actionHash = encode(
-			"updateCategory(uint,string,uint,uint,uint,uint[],uint,string,address,bytes2,uint[],string)",
+			"edit(uint,string,uint,uint,uint,uint[],uint,string,address,bytes2,uint[],string)",
 			c1,
 			"YoYo",
 			2,

--- a/test/18_TokenController.test.js
+++ b/test/18_TokenController.test.js
@@ -33,6 +33,7 @@ contract("TokenController", ([owner, account2, account3]) => {
 		plotusToken = await PlotusToken.at(plotusToken);
 		await tokenController.changeOperator(owner);
 		assert.equal(await plotusToken.operator(), owner);
+		await plotusToken.approve(tokenController.address, "1000000000000000000000000");
 	});
 
 	describe("1. Check Initialization Data", () => {
@@ -393,6 +394,7 @@ contract("TokenController", ([owner, account2, account3]) => {
 			await assertRevert(tokenController.increaseLockAmount(lockReason1, 0));
 		});
 		it("Should increaseLockAmount and time for reason3", async () => {
+			await plotusToken.approve(tokenController.address, "1000000000000000000000000", { from: account2 });
 			await tokenController.lock(lockReason2, lockedAmount, thirtyDayPeriod, { from: account2 });
 			let oldStatus = await tokenController.locked(account2, lockReason2);
 			await tokenController.increaseLockAmount(lockReason2, 1, { from: account2 });

--- a/test/19_UpdateConfigParams.test.js
+++ b/test/19_UpdateConfigParams.test.js
@@ -11,6 +11,7 @@ const MockchainLink = artifacts.require('MockChainLinkAggregator');
 const OwnedUpgradeabilityProxy = artifacts.require('OwnedUpgradeabilityProxy');
 const gvProposal = require('./utils/gvProposal.js').gvProposalWithIncentiveViaTokenHolder;
 const encode = require('./utils/encoder.js').encode;
+const assertRevert = require("./utils/assertRevert").assertRevert;
 const {toHex, toWei, toChecksumAddress} = require('./utils/ethTools');
 const { takeSnapshot, revertSnapshot } = require('./utils/snapshot');
 
@@ -195,6 +196,9 @@ contract('Configure Global Parameters', accounts => {
         await updateParameter(21, 2, 'CLORCLE', pl, 'configAddress', pl.address);
         let configData = await marketConfig.getFeedAddresses();
         assert.equal(configData[0], pl.address, 'Not updated');
+      });
+      it('Should not allow to update if unauthorized call', async function() {
+        await assertRevert(marketConfig.updateAddressParameters(toHex("CLORCLE"),pl.address));
       });
 
       it('Should update Uniswap Factory', async function() {

--- a/test/21_weeklyMarketOptionPrice.js
+++ b/test/21_weeklyMarketOptionPrice.js
@@ -5,6 +5,7 @@ const OwnedUpgradeabilityProxy = artifacts.require("OwnedUpgradeabilityProxy");
 const Master = artifacts.require("Master");
 const PlotusToken = artifacts.require("MockPLOT");
 const MarketConfig = artifacts.require("MockConfig");
+const TokenController = artifacts.require("TokenController");
 const MockchainLinkBTC = artifacts.require("MockChainLinkAggregator");
 const BLOT = artifacts.require("BLOT");
 const web3 = Market.web3;
@@ -19,6 +20,7 @@ contract("Market", async function([user1, user2, user3, user4, user5, user6, use
 		let BLOTInstance = await BLOT.deployed();
 		let MockchainLinkInstance = await MockchainLinkBTC.deployed();
 		let plotusNewAddress = await masterInstance.getLatestAddress(web3.utils.toHex("PL"));
+		tokenController  =await TokenController.at(await masterInstance.getLatestAddress(web3.utils.toHex("TC")));
 		let plotusNewInstance = await Plotus.at(plotusNewAddress);
 		let marketConfig = await plotusNewInstance.marketUtility();
 		marketConfig = await MarketConfig.at(marketConfig);
@@ -107,7 +109,7 @@ contract("Market", async function([user1, user2, user3, user4, user5, user6, use
 
 		
 
-		await plotusToken.approve(marketInstance.address, "10000000000000000000000");
+		await plotusToken.approve(tokenController.address, "10000000000000000000000");
 		await marketInstance.placePrediction(plotusToken.address, "100000000000000000000", 1, 1, {
 			from: user1,
 		});
@@ -171,7 +173,7 @@ contract("Market", async function([user1, user2, user3, user4, user5, user6, use
 
 		
 
-		await plotusToken.approve(marketInstance.address, "10000000000000000000000");
+		await plotusToken.approve(tokenController.address, "10000000000000000000000");
 		await marketInstance.placePrediction(plotusToken.address, "100000000000000000000", 1, 1, {
 			from: user1,
 		});
@@ -250,7 +252,7 @@ contract("Market", async function([user1, user2, user3, user4, user5, user6, use
 
 		
 
-		await plotusToken.approve(marketInstance.address, "10000000000000000000000");
+		await plotusToken.approve(tokenController.address, "10000000000000000000000");
 		await marketInstance.placePrediction(plotusToken.address, "100000000000000000000", 1, 1, {
 			from: user1,
 		});
@@ -329,7 +331,7 @@ contract("Market", async function([user1, user2, user3, user4, user5, user6, use
 
 		
 
-		await plotusToken.approve(marketInstance.address, "10000000000000000000000");
+		await plotusToken.approve(tokenController.address, "10000000000000000000000");
 		await marketInstance.placePrediction(plotusToken.address, "1000000000000000000000", 1, 1, {
 			from: user1,
 		});
@@ -408,7 +410,7 @@ contract("Market", async function([user1, user2, user3, user4, user5, user6, use
 
 		
 
-		await plotusToken.approve(marketInstance.address, "10000000000000000000000");
+		await plotusToken.approve(tokenController.address, "10000000000000000000000");
 		await marketInstance.placePrediction(plotusToken.address, "1000000000000000000000", 1, 1, {
 			from: user1,
 		});

--- a/test/23_cummulativePrices.test.js
+++ b/test/23_cummulativePrices.test.js
@@ -139,6 +139,7 @@ contract("MarketUtility", async function([user1, user2, user3, user4, user5, use
     	await increaseTime(3610);
     	await marketConfig.setInitialCummulativePrice();
     	await mockUniswapV2Pair.sync();
+    	await increaseTime(3610);
     	await plotusNewInstance.createMarket(0,0);
     	await plotusNewInstance.createMarket(0,1);
     	await increaseTime(3610);

--- a/test/23_cummulativePrices.test.js
+++ b/test/23_cummulativePrices.test.js
@@ -1,0 +1,164 @@
+const { assert } = require("chai");
+const OwnedUpgradeabilityProxy = artifacts.require("OwnedUpgradeabilityProxy");
+const Market = artifacts.require("MockMarket");
+const Plotus = artifacts.require("MarketRegistry");
+const Master = artifacts.require("Master");
+const MemberRoles = artifacts.require("MemberRoles");
+const PlotusToken = artifacts.require("MockPLOT");
+const MockWeth = artifacts.require("MockWeth");
+const MarketUtility = artifacts.require("MockMarketUtility");
+const MockConfig = artifacts.require("MockConfig");
+const Governance = artifacts.require("Governance");
+const MockUniswapRouter = artifacts.require("MockUniswapRouter");
+const MockUniswapV2Pair = artifacts.require("MockUniswapV2Pair");
+const MockUniswapFactory = artifacts.require('MockUniswapFactory');
+const TokenController = artifacts.require("MockTokenController");
+const web3 = Market.web3;
+const increaseTime = require("./utils/increaseTime.js").increaseTime;
+const assertRevert = require("./utils/assertRevert").assertRevert;
+const latestTime = require("./utils/latestTime").latestTime;
+const encode = require('./utils/encoder.js').encode;
+const {toHex, toWei, toChecksumAddress} = require('./utils/ethTools');
+const gvProposal = require('./utils/gvProposal.js').gvProposalWithIncentiveViaTokenHolder;
+
+var initialPLOTPrice;
+var initialEthPrice;
+const ethAddress = "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE";
+var nullAddress = "0x0000000000000000000000000000000000000000";
+
+contract("MarketUtility", async function([user1, user2, user3, user4, user5, user6, user7, user8, user9, user10, user11, user12]) {
+	let masterInstance,
+		plotusToken,
+		marketConfig,
+		MockUniswapRouterInstance,
+		tokenControllerAdd,
+		tokenController,
+		plotusNewAddress,
+		plotusNewInstance, governance,
+		mockUniswapV2Pair,
+		mockUniswapFactory, weth;
+	before(async () => {
+		masterInstance = await OwnedUpgradeabilityProxy.deployed();
+		masterInstance = await Master.at(masterInstance.address);
+		plotusToken = await PlotusToken.deployed();
+		tokenControllerAdd = await masterInstance.getLatestAddress(web3.utils.toHex("TC"));
+		tokenController = await TokenController.at(tokenControllerAdd);
+		plotusNewAddress = await masterInstance.getLatestAddress(web3.utils.toHex("PL"));
+		memberRoles = await masterInstance.getLatestAddress(web3.utils.toHex("MR"));
+		memberRoles = await MemberRoles.at(memberRoles);
+		governance = await masterInstance.getLatestAddress(web3.utils.toHex("GV"));
+		governance = await Governance.at(governance);
+		MockUniswapRouterInstance = await MockUniswapRouter.deployed();
+		mockUniswapFactory = await MockUniswapFactory.deployed();
+		plotusNewInstance = await Plotus.at(plotusNewAddress);
+		marketConfig = await plotusNewInstance.marketUtility();
+		marketConfig = await MockConfig.at(marketConfig);
+		weth = await MockWeth.deployed();
+		await marketConfig.setWeth(weth.address);
+	});
+
+	it('Should Update Existing Markets Implementation', async function() {
+        let newUtility = await MarketUtility.new();
+        let existingMarkets = await plotusNewInstance.getOpenMarkets();
+        let actionHash = encode(
+          'upgradeContractImplementation(address,address)',
+          marketConfig.address,
+          newUtility.address
+        );
+        await gvProposal(
+          6,
+          actionHash,
+          await MemberRoles.at(await masterInstance.getLatestAddress(toHex('MR'))),
+          governance,
+          2,
+          0
+        );
+        await increaseTime(604800);
+        marketConfig = await MarketUtility.at(marketConfig.address);
+    });
+
+    it("Should not allow to re initialize Utility after updating Implementation", async function() {
+    	await assertRevert(marketConfig.initialize([user1, MockUniswapRouterInstance.address, plotusToken.address, mockUniswapFactory.address]))
+    });
+
+    it("Deploy uniswap v2 pair and add liquidity", async function() {
+    	mockUniswapV2Pair = await MockUniswapV2Pair.new();
+    	await mockUniswapV2Pair.initialize(plotusToken.address, weth.address);
+      	await weth.deposit({from: user12, value: toWei(10)});
+    	await weth.transfer(mockUniswapV2Pair.address, toWei(10),{from: user12});
+    	await plotusToken.transfer(mockUniswapV2Pair.address, toWei(1000));
+    	initialPLOTPrice = 1000/10;
+    	initialEthPrice = 10/1000;
+    	await mockUniswapFactory.setPair(mockUniswapV2Pair.address);
+    	await mockUniswapV2Pair.sync();
+    });
+
+    it('Should not update market config address parameters if zero address', async function() {
+        let newUtility = await MarketUtility.new();
+        let existingMarkets = await plotusNewInstance.getOpenMarkets();
+        let actionHash = encode(
+          'updateConfigAddressParameters(bytes8,address)',
+          toHex("UNIFAC"),
+          nullAddress
+        );
+        let proposalId = await governance.getProposalLength();
+        await gvProposal(
+          21,
+          actionHash,
+          await MemberRoles.at(await masterInstance.getLatestAddress(toHex('MR'))),
+          governance,
+          2,
+          0
+        );
+        assert.notEqual(3, (await governance.proposalActionStatus(proposalId))/1);
+        await increaseTime(604800);
+    });
+
+    it('Should Update market config address parameters', async function() {
+        let newUtility = await MarketUtility.new();
+        let existingMarkets = await plotusNewInstance.getOpenMarkets();
+        let actionHash = encode(
+          'updateConfigAddressParameters(bytes8,address)',
+          toHex("UNIFAC"),
+          mockUniswapFactory.address
+        );
+        let proposalId = await governance.getProposalLength();
+        await gvProposal(
+          21,
+          actionHash,
+          await MemberRoles.at(await masterInstance.getLatestAddress(toHex('MR'))),
+          governance,
+          2,
+          0
+        );
+        assert.equal(3, (await governance.proposalActionStatus(proposalId))/1);
+        await increaseTime(604800);
+    });
+
+    it("Check price of plot", async function() {
+    	await increaseTime(3610);
+    	await marketConfig.setInitialCummulativePrice();
+    	await mockUniswapV2Pair.sync();
+    	await plotusNewInstance.createMarket(0,0);
+    	await plotusNewInstance.createMarket(0,1);
+    	await increaseTime(3610);
+    	await mockUniswapV2Pair.sync();
+    	await plotusNewInstance.createMarket(0,0);
+    	await increaseTime(3610);
+    	await mockUniswapV2Pair.sync();
+    	let currentPrice = (await marketConfig.getPrice(mockUniswapV2Pair.address, toWei(1)))/1;
+    	assert.equal(initialEthPrice, currentPrice/1e18);
+    	let plotPriceInEth = ((await marketConfig.getAssetPriceInETH(plotusToken.address))[0])/1;
+    	assert.equal(initialEthPrice, plotPriceInEth/1e18);
+    	let ethPriceInEth = ((await marketConfig.getAssetPriceInETH(ethAddress))[0])/1;
+    	assert.equal(ethPriceInEth, 1);
+    });
+
+    it("Get asset price in PLOT", async function() {
+    	let currentPrice = (await marketConfig.getValueAndMultiplierParameters(ethAddress, "1000000000000000000"))
+    	assert.equal(initialPLOTPrice, currentPrice[1]/1e18);
+    	currentPrice = (await marketConfig.getValueAndMultiplierParameters(plotusToken.address, "1000000000000000000"))
+    	assert.equal(1, currentPrice[1]/1e18);
+    });
+    
+});

--- a/test/utils/gvProposal.js
+++ b/test/utils/gvProposal.js
@@ -24,7 +24,7 @@ async function gvProposal(...args) {
   let proposal = await gv.proposal(p);
   assert.equal(proposal[2].toNumber(), 3);
   if (seq != 1) {
-    await increaseTime(3601);
+    await increaseTime(86401);
     await gv.triggerAction(p);
   }
 }
@@ -51,7 +51,7 @@ async function gvProposalWithIncentive(...args) {
   if (seq != 3) await gv.closeProposal(p);
   let proposal = await gv.proposal(p);
   assert.equal(proposal[2].toNumber(), 3);
-  await increaseTime(3601);
+  await increaseTime(86401);
   await gv.triggerAction(p);
 }
 
@@ -79,7 +79,7 @@ async function gvProposalWithIncentiveViaTokenHolder(...args) {
   let proposal = await gv.proposal(p);
   assert.equal(proposal[2].toNumber(), 3);
   if(!skipTrigger) {
-    await increaseTime(3601);
+    await increaseTime(86401);
     await gv.triggerAction(p);
   }
 }

--- a/truffle-config.js
+++ b/truffle-config.js
@@ -93,8 +93,8 @@ module.exports = {
        optimizer: {
          enabled: true,
          runs: 200
-       }
-      //  evmVersion: "byzantium"
+       },
+       evmVersion: "constantinople"
       }
     }
   }


### PR DESCRIPTION
Fixed issue in TC, Tokens were burnt from unlocked tokens also
Added a check to restrict creating proposals with category raise dispute
Transfer back proposal default incentives if proposal is over period of max draft time
Updated default market type neutral option range percentages
Ceil the neutral option min,max ranges
Removed operatorTransfer
Use transfer from function of TC in Market while collecting users tokens, avoids giving allowance to every new market
New option range percent calculation 
     neutral option min value = CEIL((current price - current price*optionRangePerc/100)/roundOfToNearest)*roundOfToNearest
     neutral option max value = CEIL((current price + current price*optionRangePerc/100)/roundOfToNearest)*roundOfToNearest